### PR TITLE
feat: post page markdown parser 적용

### DIFF
--- a/frontend/src/pages/PostPage/index.js
+++ b/frontend/src/pages/PostPage/index.js
@@ -1,7 +1,13 @@
 import { useParams } from 'react-router';
-import { Card, ProfileChip } from '../../components';
 import useFetch from '../../hooks/useFetch';
 import { requestGetPost } from '../../service/requests';
+
+import { Card, ProfileChip } from '../../components';
+import { Viewer } from '@toast-ui/react-editor';
+
+import 'codemirror/lib/codemirror.css';
+import '@toast-ui/editor/dist/toastui-editor.css';
+
 import {
   CardInner,
   SubHeader,
@@ -22,22 +28,6 @@ const PostPage = () => {
     <>해당 글을 찾을 수 없습니다.</>;
   }
 
-  //   {
-  //     localeMatcher?: "best fit" | "lookup";
-  //     weekday?: "long" | "short" | "narrow";
-  //     era?: "long" | "short" | "narrow";
-  //     year?: "numeric" | "2-digit";
-  //     month?: "numeric" | "2-digit" | "long" | "short" | "narrow";
-  //     day?: "numeric" | "2-digit";
-  //     hour?: "numeric" | "2-digit";
-  //     minute?: "numeric" | "2-digit";
-  //     second?: "numeric" | "2-digit";
-  //     timeZoneName?: "long" | "short";
-  //     formatMatcher?: "best fit" | "basic";
-  //     hour12?: boolean;
-  //     timeZone?: string;
-  // }
-
   return (
     <Card key={id} size="LARGE">
       <CardInner>
@@ -51,7 +41,9 @@ const PostPage = () => {
             {author?.nickname}
           </ProfileChip>
         </div>
-        <Content>{content}</Content>
+        <div>
+          <Viewer initialValue={content} />
+        </div>
         <Tags>
           {tags?.map(({ id, name }) => (
             <span key={id}>{`#${name} `}</span>

--- a/frontend/src/pages/PostPage/styles.js
+++ b/frontend/src/pages/PostPage/styles.js
@@ -7,7 +7,7 @@ const CardInner = styled.div`
   height: 100%;
 
   & > *:not(:last-child) {
-    margin-bottom: 6rem;
+    margin-bottom: 2rem;
   }
 `;
 
@@ -29,11 +29,6 @@ const Title = styled.div`
   margin-bottom: 2rem;
 `;
 
-const Content = styled.div`
-  line-break: anywhere;
-  white-space: break-spaces;
-`;
-
 const Tags = styled.div`
   font-size: 1.4rem;
   color: #848484;
@@ -50,4 +45,4 @@ const ProfileChipStyle = css`
   padding: 0;
 `;
 
-export { CardInner, SubHeader, Mission, Title, Content, Tags, IssuedDate, ProfileChipStyle };
+export { CardInner, SubHeader, Mission, Title, Tags, IssuedDate, ProfileChipStyle };


### PR DESCRIPTION
- post page 화면에서 markdown이 파싱된 채로 출력되는 기능 추가

<img width="1434" alt="스크린샷 2021-07-03 오후 10 19 08" src="https://user-images.githubusercontent.com/67677561/124355598-f4588800-dc4c-11eb-9a39-ff2c23e6de8a.png">
