### PR TITLE
fix: 프로필 페이지 관련 버그 픽스

### DIFF
--- a/frontend/src/pages/ProfilePage/index.js
+++ b/frontend/src/pages/ProfilePage/index.js
@@ -20,15 +20,13 @@ import {
 } from './styles';
 import { PROFILE_PAGE_MENU } from '../../constants';
 import { requestGetProfile } from '../../service/requests';
-import useFetch from '../../hooks/useFetch';
 
 const ProfilePage = ({ children, menu }) => {
   const history = useHistory();
   const { username } = useParams();
 
+  const [user, setUser] = useState({});
   const [selectedMenu, setSelectedMenu] = useState('');
-
-  const [user] = useFetch({}, () => requestGetProfile(username));
 
   const goProfilePage = (event) => {
     setSelectedMenu(event.currentTarget.value);
@@ -43,6 +41,25 @@ const ProfilePage = ({ children, menu }) => {
   const goProfilePageAccount = () => {
     history.push(`/${username}/account`);
   };
+
+  const getProfile = async () => {
+    try {
+      const response = await requestGetProfile(username);
+
+      if (!response.ok) {
+        throw new Error();
+      }
+
+      setUser(await response.json());
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  useEffect(() => {
+    getProfile();
+    setSelectedMenu(menu);
+  }, [username]);
 
   useEffect(() => {
     setSelectedMenu(menu);

--- a/frontend/src/pages/ProfilePagePosts/index.js
+++ b/frontend/src/pages/ProfilePagePosts/index.js
@@ -30,13 +30,13 @@ const ProfilePagePosts = () => {
 
   const { error: postError, deleteData: deletePost } = usePost({});
 
-  const goTargetPost = (id) => (event) => {
-    if (event?.target !== event?.currentTarget) return;
-
+  const goTargetPost = (id) => {
     history.push(`${PATH.POST}/${id}`);
   };
 
-  const goEditTargetPost = (id) => {
+  const goEditTargetPost = (id) => (event) => {
+    event.stopPropagation();
+
     history.push(`${PATH.POST}/${id}/edit`);
   };
 
@@ -82,7 +82,7 @@ const ProfilePagePosts = () => {
             <PostItem
               key={id}
               size="SMALL"
-              onClick={goTargetPost(id)}
+              onClick={() => goTargetPost(id)}
               onMouseEnter={() => setHoveredPostId(id)}
               onMouseLeave={() => setHoveredPostId(0)}
             >
@@ -104,7 +104,7 @@ const ProfilePagePosts = () => {
                     type="button"
                     css={EditButtonStyle}
                     alt="수정 버튼"
-                    onClick={() => goEditTargetPost(id)}
+                    onClick={goEditTargetPost(id)}
                   >
                     수정
                   </Button>


### PR DESCRIPTION
버그 목록
1. 다른 사람 프로필 페이지에서 내 프로필 페이지로 이동 시, 알맞은 프로필이 뜨도록 수정
2. 프로필 페이지 내에서, content tab과 content 내용이 올바르게 매칭되지 않는 버그 수정
3. 내가 쓴 글 목록에서 글 클릭시 해당 글 상세페이지로 갈 때, 클릭 영역 수정