### PR TITLE
refactor: Post Page 내용 폰트 크기 13px에서 16px로 변경

### DIFF
--- a/frontend/src/pages/PostPage/styles.js
+++ b/frontend/src/pages/PostPage/styles.js
@@ -9,6 +9,10 @@ const CardInner = styled.div`
   & > *:not(:last-child) {
     margin-bottom: 2rem;
   }
+
+  .tui-editor-contents {
+    font-size: 1.6rem;
+  }
 `;
 
 const SubHeader = styled.div`


### PR DESCRIPTION
### fix #183

Post Page 내용 폰트 크기 13px에서 16px로 변경

### 전
<img width="1142" alt="스크린샷 2021-07-22 오후 4 01 44" src="https://user-images.githubusercontent.com/67677561/126600922-37a60dd0-299c-4d37-a691-ff221c30a3f2.png">


### 후 
<img width="1155" alt="스크린샷 2021-07-22 오후 4 00 49" src="https://user-images.githubusercontent.com/67677561/126600888-582f8d6c-eddb-4d37-bb8d-29c139b45027.png">
