### PR TITLE
refactor: SelectBox 컴포넌트 리팩토링

### DIFF
--- a/frontend/src/components/SelectBox/SelectBox.js
+++ b/frontend/src/components/SelectBox/SelectBox.js
@@ -17,10 +17,10 @@ const SelectBox = ({
   const $label = useRef(null);
   const $selectorContainer = useRef(null);
 
-  const [isSelectBoxOpen, setIsSelectBoxOpen] = useCustomSelectBox({ targetRef: $label });
+  const [selectItems, setSelectItems] = useCustomSelectBox({ targetRef: $label });
   useScrollToSelected({
     container: $selectorContainer,
-    dependency: isSelectBoxOpen,
+    dependency: selectItems,
     options,
     selectedOption,
   });
@@ -29,14 +29,28 @@ const SelectBox = ({
     event.stopPropagation();
 
     option ? setSelectedOption(option) : setSelectedOption(event.target.value);
-    setIsSelectBoxOpen(false);
+    setSelectItems(false);
   };
 
   const onOpenCustomSelectBox = (event) => {
     event.preventDefault();
 
-    setIsSelectBoxOpen(true);
+    setSelectItems(getSelectItems());
   };
+
+  const getSelectItems = () => (
+    <SelectItems ref={$selectorContainer} maxHeight={maxHeight}>
+      {options.map((option) => (
+        <SelectItem
+          key={option}
+          onMouseDown={(event) => onSelectItem(event, option)}
+          isSelected={option === selectedOption}
+        >
+          {option}
+        </SelectItem>
+      ))}
+    </SelectItems>
+  );
 
   return (
     <Label aria-label={title} ref={$label} onMouseDown={onOpenCustomSelectBox} width={width}>
@@ -47,20 +61,7 @@ const SelectBox = ({
           </option>
         ))}
       </Select>
-
-      {isSelectBoxOpen && (
-        <SelectItems ref={$selectorContainer} maxHeight={maxHeight}>
-          {options.map((option) => (
-            <SelectItem
-              key={option}
-              onMouseDown={(event) => onSelectItem(event, option)}
-              isSelected={option === selectedOption}
-            >
-              {option}
-            </SelectItem>
-          ))}
-        </SelectItems>
-      )}
+      {selectItems}
     </Label>
   );
 };

--- a/frontend/src/components/SelectBox/SelectBox.js
+++ b/frontend/src/components/SelectBox/SelectBox.js
@@ -39,7 +39,7 @@ const SelectBox = ({
   };
 
   return (
-    <Label ref={$label} onMouseDown={onOpenCustomSelectBox} title={title} width={width}>
+    <Label aria-label={title} ref={$label} onMouseDown={onOpenCustomSelectBox} width={width}>
       <Select name={name} onChange={onSelectItem} value={selectedOption}>
         {options.map((option) => (
           <option key={option} value={option}>
@@ -50,17 +50,15 @@ const SelectBox = ({
 
       {isSelectBoxOpen && (
         <SelectItems ref={$selectorContainer} maxHeight={maxHeight}>
-          {options.map((option) => {
-            return (
-              <SelectItem
-                key={option}
-                onMouseDown={(event) => onSelectItem(event, option)}
-                isSelected={option === selectedOption}
-              >
-                {option}
-              </SelectItem>
-            );
-          })}
+          {options.map((option) => (
+            <SelectItem
+              key={option}
+              onMouseDown={(event) => onSelectItem(event, option)}
+              isSelected={option === selectedOption}
+            >
+              {option}
+            </SelectItem>
+          ))}
         </SelectItems>
       )}
     </Label>

--- a/frontend/src/components/SelectBox/SelectBox.js
+++ b/frontend/src/components/SelectBox/SelectBox.js
@@ -17,10 +17,10 @@ const SelectBox = ({
   const $label = useRef(null);
   const $selectorContainer = useRef(null);
 
-  const [selectItems, setSelectItems] = useCustomSelectBox({ targetRef: $label });
+  const [isSelectBoxOpened, setIsSelectBoxOpened] = useCustomSelectBox({ targetRef: $label });
   useScrollToSelected({
     container: $selectorContainer,
-    dependency: selectItems,
+    dependency: isSelectBoxOpened,
     options,
     selectedOption,
   });
@@ -29,28 +29,14 @@ const SelectBox = ({
     event.stopPropagation();
 
     option ? setSelectedOption(option) : setSelectedOption(event.target.value);
-    setSelectItems(false);
+    setIsSelectBoxOpened(false);
   };
 
   const onOpenCustomSelectBox = (event) => {
     event.preventDefault();
 
-    setSelectItems(getSelectItems());
+    setIsSelectBoxOpened(true);
   };
-
-  const getSelectItems = () => (
-    <SelectItems ref={$selectorContainer} maxHeight={maxHeight}>
-      {options.map((option) => (
-        <SelectItem
-          key={option}
-          onMouseDown={(event) => onSelectItem(event, option)}
-          isSelected={option === selectedOption}
-        >
-          {option}
-        </SelectItem>
-      ))}
-    </SelectItems>
-  );
 
   return (
     <Label aria-label={title} ref={$label} onMouseDown={onOpenCustomSelectBox} width={width}>
@@ -61,7 +47,19 @@ const SelectBox = ({
           </option>
         ))}
       </Select>
-      {selectItems}
+      {isSelectBoxOpened && (
+        <SelectItems ref={$selectorContainer} maxHeight={maxHeight}>
+          {options.map((option) => (
+            <SelectItem
+              key={option}
+              onMouseDown={(event) => onSelectItem(event, option)}
+              isSelected={option === selectedOption}
+            >
+              {option}
+            </SelectItem>
+          ))}
+        </SelectItems>
+      )}
     </Label>
   );
 };

--- a/frontend/src/components/SelectBox/SelectBox.js
+++ b/frontend/src/components/SelectBox/SelectBox.js
@@ -66,8 +66,8 @@ const SelectBox = ({
 
 SelectBox.propTypes = {
   options: PropTypes.array.isRequired,
-  selectedOption: PropTypes.string,
-  setSelectedOption: PropTypes.func,
+  selectedOption: PropTypes.string.isRequired,
+  setSelectedOption: PropTypes.func.isRequired,
   title: PropTypes.string.isRequired,
   name: PropTypes.string.isRequired,
   width: PropTypes.string,

--- a/frontend/src/components/SelectBox/SelectBox.styles.js
+++ b/frontend/src/components/SelectBox/SelectBox.styles.js
@@ -6,7 +6,6 @@ const Label = styled.label`
   display: inline-block;
   width: ${({ width }) => width ?? `${width}`};
 
-  // 삼각형 화살표 부분
   &::after {
     content: '';
     display: inline-block;
@@ -55,7 +54,6 @@ const SelectItems = styled.ul`
   border: 2px solid ${COLOR.DARK_BLUE_800};
   border-radius: 1rem;
 
-  // 스크롤바 커스텀을 위한 코드
   & {
     ::-webkit-scrollbar {
       width: 1rem;

--- a/frontend/src/components/SelectBox/SelectBox.styles.js
+++ b/frontend/src/components/SelectBox/SelectBox.styles.js
@@ -35,8 +35,6 @@ const Select = styled.select`
   cursor: pointer;
 
   appearance: none;
-  -moz-appearance: none;
-  -webkit-appearance: none;
 `;
 
 const SelectItems = styled.ul`

--- a/frontend/src/components/SelectBox/SelectBox.styles.js
+++ b/frontend/src/components/SelectBox/SelectBox.styles.js
@@ -2,84 +2,81 @@ import styled from '@emotion/styled';
 import COLOR from '../../constants/color';
 
 const Label = styled.label`
-  display: inline-block;
   position: relative;
-  width: 100%;
+  display: inline-block;
+  width: ${({ width }) => width ?? `${width}`};
 
+  // 삼각형 화살표 부분
   &::after {
     content: '';
     display: inline-block;
     position: absolute;
-    right: 2.6rem;
-    top: 40%;
+    right: 2rem;
+    top: 45%;
 
-    border-radius: 2px;
     border: solid 0.8rem transparent;
     border-top-color: ${COLOR.BLACK_600};
+    border-radius: 0.125rem;
+    cursor: pointer;
   }
 `;
 
 const Select = styled.select`
-  display: block;
-  padding: 1.2rem 2rem;
+  padding: 1rem 2rem;
   width: 100%;
-  min-height: 3rem;
+
   font-size: 1.6rem;
+  line-height: 1.5;
   font-family: inherit;
 
   background-color: ${COLOR.WHITE};
-  outline: none;
   border: 2px solid ${COLOR.DARK_BLUE_800};
-  border-radius: 1.6rem;
+  border-radius: 1rem;
+  outline: none;
   cursor: pointer;
+
   appearance: none;
+  -moz-appearance: none;
+  -webkit-appearance: none;
 `;
 
 const SelectItems = styled.ul`
   position: absolute;
+  top: 0;
   width: 100%;
-  max-height: 42rem;
+  max-height: ${({ maxHeight }) => maxHeight ?? `${maxHeight}`};
   overflow-y: auto;
-  top: 0%;
+
   list-style: none;
-  margin: 0;
   z-index: 1;
+
   color: ${COLOR.DARK_BLUE_800};
-
-  background-color: ${COLOR.DARK_GRAY_200};
-  border-radius: 1.6rem;
+  background-color: ${COLOR.LIGHT_GRAY_200};
   border: 2px solid ${COLOR.DARK_BLUE_800};
+  border-radius: 1rem;
 
+  // 스크롤바 커스텀을 위한 코드
   & {
     ::-webkit-scrollbar {
-      width: 0;
+      width: 1rem;
     }
 
     ::-webkit-scrollbar-track {
       margin: 1rem 0;
-      border-radius: 10px;
+      border-radius: 1rem;
     }
 
     ::-webkit-scrollbar-thumb {
       background-color: ${COLOR.DARK_BLUE_800};
-      border-radius: 10px;
+      border-radius: 1rem;
     }
-
-    ::-webkit-scrollbar-thumb:hover {
-      background-color: ${COLOR.DARK_BLUE_800};
-    }
-  }
-
-  &:hover::-webkit-scrollbar {
-    width: 1rem;
   }
 `;
 
 const SelectItem = styled.li`
   display: flex;
   align-items: center;
-  padding: 1.2rem 2rem;
-  min-height: 3rem;
+  padding: 1rem 2rem;
   font-size: 1.6rem;
   cursor: pointer;
   background-color: ${COLOR.WHITE};
@@ -89,13 +86,13 @@ const SelectItem = styled.li`
   }
 
   &:first-of-type:hover {
-    border-top-right-radius: 1.6rem;
-    border-top-left-radius: 1.6rem;
+    border-top-right-radius: 1rem;
+    border-top-left-radius: 1rem;
   }
 
   &:last-child:hover {
-    border-bottom-right-radius: 1.6rem;
-    border-bottom-left-radius: 1.6rem;
+    border-bottom-right-radius: 1rem;
+    border-bottom-left-radius: 1rem;
   }
 
   ${({ isSelected }) =>

--- a/frontend/src/components/SelectBox/SelectBox.styles.js
+++ b/frontend/src/components/SelectBox/SelectBox.styles.js
@@ -47,7 +47,7 @@ const SelectItems = styled.ul`
   overflow-y: auto;
 
   list-style: none;
-  z-index: 1;
+  z-index: 7;
 
   color: ${COLOR.DARK_BLUE_800};
   background-color: ${COLOR.LIGHT_GRAY_200};

--- a/frontend/src/components/SelectBox/SelectBox.styles.js
+++ b/frontend/src/components/SelectBox/SelectBox.styles.js
@@ -98,11 +98,11 @@ const SelectItem = styled.li`
     `background-color: ${COLOR.LIGHT_BLUE_200};
     
     &:first-of-type {
-      border-top-left-radius: 22px;
+      border-top-left-radius: 1rem;
     }
 
     &:last-child {
-      border-bottom-left-radius: 22px;
+      border-bottom-left-radius: 1rem;
     }`}
 `;
 

--- a/frontend/src/hooks/useCustomSelectBox.js
+++ b/frontend/src/hooks/useCustomSelectBox.js
@@ -1,14 +1,15 @@
 import { useEffect, useState } from 'react';
 
 const useCustomSelectBox = ({ targetRef }) => {
-  const [isSelectBoxOpen, setIsSelectBoxOpen] = useState(false);
+  const [selectItems, setSelectItems] = useState(null);
 
   useEffect(() => {
-    const onCloseOptionList = (event) => {
-      event.preventDefault();
+    const onCloseOptionList = (e) => {
+      if (!selectItems) return;
+      e.preventDefault();
 
-      if (!targetRef.current?.contains(event.target)) {
-        setIsSelectBoxOpen(false);
+      if (!targetRef.current?.contains(e.target)) {
+        setSelectItems(null);
       }
     };
 
@@ -17,9 +18,9 @@ const useCustomSelectBox = ({ targetRef }) => {
     return () => {
       document.removeEventListener('click', onCloseOptionList);
     };
-  }, [isSelectBoxOpen, targetRef]);
+  }, [selectItems, targetRef]);
 
-  return [isSelectBoxOpen, setIsSelectBoxOpen];
+  return [selectItems, setSelectItems];
 };
 
 export default useCustomSelectBox;

--- a/frontend/src/hooks/useCustomSelectBox.js
+++ b/frontend/src/hooks/useCustomSelectBox.js
@@ -1,0 +1,25 @@
+import { useEffect, useState } from 'react';
+
+const useCustomSelectBox = ({ targetRef }) => {
+  const [isSelectBoxOpen, setIsSelectBoxOpen] = useState(false);
+
+  useEffect(() => {
+    const onCloseOptionList = (event) => {
+      event.preventDefault();
+
+      if (!targetRef.current?.contains(event.target)) {
+        setIsSelectBoxOpen(false);
+      }
+    };
+
+    document.addEventListener('click', onCloseOptionList);
+
+    return () => {
+      document.removeEventListener('click', onCloseOptionList);
+    };
+  }, [isSelectBoxOpen, targetRef]);
+
+  return [isSelectBoxOpen, setIsSelectBoxOpen];
+};
+
+export default useCustomSelectBox;

--- a/frontend/src/hooks/useCustomSelectBox.js
+++ b/frontend/src/hooks/useCustomSelectBox.js
@@ -1,15 +1,16 @@
 import { useEffect, useState } from 'react';
 
 const useCustomSelectBox = ({ targetRef }) => {
-  const [selectItems, setSelectItems] = useState(null);
+  const [isSelectBoxOpened, setIsSelectBoxOpened] = useState(false);
 
   useEffect(() => {
-    const onCloseOptionList = (e) => {
-      if (!selectItems) return;
-      e.preventDefault();
+    const onCloseOptionList = (event) => {
+      if (!isSelectBoxOpened) return;
 
-      if (!targetRef.current?.contains(e.target)) {
-        setSelectItems(null);
+      event.preventDefault();
+
+      if (!targetRef.current?.contains(event.target)) {
+        setIsSelectBoxOpened(false);
       }
     };
 
@@ -18,9 +19,9 @@ const useCustomSelectBox = ({ targetRef }) => {
     return () => {
       document.removeEventListener('click', onCloseOptionList);
     };
-  }, [selectItems, targetRef]);
+  }, [isSelectBoxOpened, targetRef]);
 
-  return [selectItems, setSelectItems];
+  return [isSelectBoxOpened, setIsSelectBoxOpened];
 };
 
 export default useCustomSelectBox;

--- a/frontend/src/hooks/useScrollToSelected.js
+++ b/frontend/src/hooks/useScrollToSelected.js
@@ -1,0 +1,15 @@
+import { useEffect } from 'react';
+
+const useScrollToSelected = ({ container, dependency, options, selectedOption }) => {
+  useEffect(() => {
+    const target = container.current;
+    if (!target) return;
+
+    const scrollY = (target.scrollHeight / options.length) * options.indexOf(selectedOption);
+    target.scroll({ top: scrollY, behavior: 'smooth' });
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [dependency]);
+};
+
+export default useScrollToSelected;

--- a/frontend/src/pages/EditPostPage/index.js
+++ b/frontend/src/pages/EditPostPage/index.js
@@ -17,7 +17,7 @@ const EditPostPage = () => {
   const { error: postError, editData: editPost } = usePost({});
   const [post] = useFetch({}, () => requestGetPost(postId));
 
-  const [selectedMission, setSelectedMission] = useState();
+  const [selectedMission, setSelectedMission] = useState('');
   const cardRefs = useRef([]);
 
   const [missions] = useFetch([], requestGetMissions);
@@ -66,6 +66,10 @@ const EditPostPage = () => {
           options={missions?.map((mission) => mission.name)}
           selectedOption={selectedMission}
           setSelectedOption={setSelectedMission}
+          title="우아한테크코스 미션 목록입니다."
+          name="mission_subjects"
+          width="100%"
+          maxHeight="25rem"
         />
       </SelectBoxWrapper>
       <Post key={id}>

--- a/frontend/src/pages/NewPostPage/index.js
+++ b/frontend/src/pages/NewPostPage/index.js
@@ -75,6 +75,10 @@ const NewPostPage = () => {
           options={missions?.map((mission) => mission.name)}
           selectedOption={selectedMission}
           setSelectedOption={setSelectedMission}
+          title="우아한테크코스 미션 목록입니다."
+          name="mission_subjects"
+          width="100%"
+          maxHeight="25rem"
         />
       </SelectBoxWrapper>
       <ul>


### PR DESCRIPTION
resolved #254 

리포트 목록을 불러올때도 SelectBox를 사용할 것 같아서 리팩토링을 진행했습니다.

- 기존의 customSelectBox가 안보이는 상황 (ex. 스크린리더)에서는 선택을 해도 반영이 되지 않아서 이 부분도 함께 수정했습니다.
- customSelectBox의 전체 너비와 높이를 받아서 사용할 수 있도록 수정했습니다.
- label의 이름이 없어서, title(aria-label)도 컴포넌트를 사용하는 쪽에서 입력하도록 수정하였습니다.
- 로직이 너무 길어지는 것 같아서 hook으로 스크롤 위치 찾아가는 것과 selectbox를 여닫을 수 있게 분리하였습니다.
- 에디터창과 드롭다운 메뉴가 겹치는 오류를 해결하였습니다.