### PR TITLE
백엔드 로깅을 도입한다.

### DIFF
--- a/backend/src/acceptanceTest/resources/application.yml
+++ b/backend/src/acceptanceTest/resources/application.yml
@@ -24,9 +24,9 @@ spring:
       ddl-auto: create-drop
     properties:
       hibernate:
-        show_sql: true
+        show_sql: false
         format_sql: true
-        use_sql_comment: true
+        use_sql_comment: false
 logging:
   level:
     org:

--- a/backend/src/acceptanceTest/resources/logback-spring.xml
+++ b/backend/src/acceptanceTest/resources/logback-spring.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration debug="false">
+  <include resource="org/springframework/boot/logging/logback/base.xml"/>
+
+  <springProfile name="acceptance">
+    <include resource="logback/console-logger.xml"/>
+
+    <logger name="wooteco.prolog" level="DEBUG">
+      <appender-ref ref="console-logger"/>
+    </logger>
+
+    <logger name="org.hibernate.tool.hbm2ddl" level="DEBUG" additivity="false">
+      <appender-ref ref="console-logger"/>
+    </logger>
+
+    <logger name="org.hibernate.SQL" level="DEBUG" additivity="false">
+      <appender-ref ref="console-logger"/>
+    </logger>
+
+    <logger name="org.hibernate.type.descriptor.sql.BasicBinder" level="TRACE" additivity="false">
+      <appender-ref ref="db-logger-console"/>
+    </logger>
+
+    <logger name="org.hibernate.type.descriptor.sql.BasicExtractor" level="TRACE" additivity="false">
+      <appender-ref ref="db-logger-console"/>
+    </logger>
+  </springProfile>
+</configuration>

--- a/backend/src/acceptanceTest/resources/logback/console-logger.xml
+++ b/backend/src/acceptanceTest/resources/logback/console-logger.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<included>
+  <appender name="console-logger" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <charset>utf8</charset>
+      <Pattern>
+        %cyan(%d{yyyy-MM-dd HH:mm:ss}:%-4relative) %highlight(%-5level) %yellow([%C.%M]:%boldWhite(%L)]) %n    > %msg%n
+      </Pattern>
+    </encoder>
+  </appender>
+
+  <appender name="db-logger-console" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <charset>utf8</charset>
+      <Pattern>
+        %green(    > %msg%n)
+      </Pattern>
+    </encoder>
+  </appender>
+</included>

--- a/backend/src/main/java/wooteco/prolog/common/exception/ExceptionController.java
+++ b/backend/src/main/java/wooteco/prolog/common/exception/ExceptionController.java
@@ -1,15 +1,26 @@
 package wooteco.prolog.common.exception;
 
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+@Slf4j
 @RestControllerAdvice
 public class ExceptionController {
 
     @ExceptionHandler(BadRequestException.class)
-    public ResponseEntity<BadRequestExceptionDto> loginExceptionHandler(BadRequestException e) {
+    public ResponseEntity<ExceptionDto> loginExceptionHandler(BadRequestException e) {
+        log.warn(e.getMessage());
         return ResponseEntity.badRequest()
-                .body(new BadRequestExceptionDto(e.getCode(), e.getMessage()));
+                .body(new ExceptionDto(e.getCode(), e.getMessage()));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ExceptionDto> runtimeExceptionHandler(Exception e) {
+        log.error(e.getMessage());
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+            .body(new ExceptionDto(500, "알 수 없는 에러"));
     }
 }

--- a/backend/src/main/java/wooteco/prolog/common/exception/ExceptionDto.java
+++ b/backend/src/main/java/wooteco/prolog/common/exception/ExceptionDto.java
@@ -9,7 +9,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Getter
 @EqualsAndHashCode
-public class BadRequestExceptionDto {
+public class ExceptionDto {
 
     private int code;
     private String message;

--- a/backend/src/main/resources/application-local.yml
+++ b/backend/src/main/resources/application-local.yml
@@ -7,11 +7,6 @@ spring:
       ddl-auto: create-drop
     properties:
       hibernate:
-        show_sql: true
+        show_sql: false
         format_sql: true
-        use_sql_comment: true
-logging:
-  level:
-    org:
-      hibernate:
-        type: trace
+        use_sql_comment: false

--- a/backend/src/main/resources/application-test.yml
+++ b/backend/src/main/resources/application-test.yml
@@ -2,6 +2,28 @@ server:
   port: 4000
 
 github:
+  client:
+    id: test_id
+    secret: test_secret
   url:
     access-token: http://localhost:4000/github/login/oauth/access_token
     profile: http://localhost:4000/github/user
+
+security:
+  jwt:
+    token:
+      secret-key: secret_key
+      expire-length: 3600000
+
+spring:
+  jpa:
+    generate-ddl: true
+    database: h2
+    database-platform: org.hibernate.dialect.H2Dialect
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        format_sql: true
+        show_sql: false
+        use_sql_comment: false

--- a/backend/src/main/resources/logback-access.xml
+++ b/backend/src/main/resources/logback-access.xml
@@ -1,8 +1,11 @@
 <configuration>
-    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder>
-            <pattern>%n###### HTTP Request ######%n%fullRequest%n###### HTTP Response ######%n%fullResponse%n%n</pattern>
-        </encoder>
-    </appender>
-    <appender-ref ref="STDOUT" />
+    <springProfile name="prod, dev">
+        <include resource="logback/access-logger.xml"/>
+        <appender-ref ref="access-logger"/>
+    </springProfile>
+
+    <springProfile name="prod, dev, local, test">
+        <include resource="logback/console-access-logger.xml"/>
+        <appender-ref ref="console-access-logger"/>
+    </springProfile>
 </configuration>

--- a/backend/src/main/resources/logback-spring.xml
+++ b/backend/src/main/resources/logback-spring.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration debug="false">
+  <include resource="org/springframework/boot/logging/logback/base.xml"/>
+
+  <springProfile name="prod">
+    <include resource="logback/console-logger.xml"/>
+    <include resource="logback/db-logger.xml"/>
+    <include resource="logback/debug-logger.xml"/>
+    <include resource="logback/info-logger.xml"/>
+    <include resource="logback/warn-logger.xml"/>
+    <include resource="logback/error-logger.xml"/>
+
+    <logger name="wooteco.prolog" level="ERROR">
+      <appender-ref ref="console-logger"/>
+      <appender-ref ref="error-logger-file"/>
+    </logger>
+
+    <logger name="org.springframework" level="INFO">
+      <appender-ref ref="console-logger"/>
+      <appender-ref ref="info-logger-file"/>
+      <appender-ref ref="warn-logger-file"/>
+      <appender-ref ref="error-logger-file"/>
+    </logger>
+  </springProfile>
+
+  <springProfile name="dev">
+    <include resource="logback/console-logger.xml"/>
+    <include resource="logback/db-logger.xml"/>
+    <include resource="logback/debug-logger.xml"/>
+    <include resource="logback/info-logger.xml"/>
+    <include resource="logback/warn-logger.xml"/>
+    <include resource="logback/error-logger.xml"/>
+
+    <logger name="wooteco.prolog" level="DEBUG">
+      <appender-ref ref="console-logger"/>
+      <appender-ref ref="debug-logger-file"/>
+      <appender-ref ref="info-logger-file"/>
+      <appender-ref ref="warn-logger-file"/>
+      <appender-ref ref="error-logger-file"/>
+    </logger>
+
+    <logger name="org.springframework" level="INFO">
+      <appender-ref ref="console-logger"/>
+      <appender-ref ref="info-logger-file"/>
+      <appender-ref ref="warn-logger-file"/>
+      <appender-ref ref="error-logger-file"/>
+    </logger>
+  </springProfile>
+
+  <springProfile name="local, test">
+    <include resource="logback/console-logger.xml"/>
+
+    <logger name="wooteco.prolog" level="DEBUG">
+      <appender-ref ref="console-logger"/>
+    </logger>
+
+    <logger name="org.hibernate.SQL" level="DEBUG" additivity="false">
+      <appender-ref ref="console-logger"/>
+    </logger>
+
+    <logger name="org.hibernate.type.descriptor.sql.BasicBinder" level="TRACE" additivity="false">
+      <appender-ref ref="db-logger-console"/>
+    </logger>
+
+    <logger name="org.hibernate.type.descriptor.sql.BasicExtractor" level="TRACE" additivity="false">
+      <appender-ref ref="db-logger-console"/>
+    </logger>
+  </springProfile>
+</configuration>

--- a/backend/src/main/resources/logback/access-logger.xml
+++ b/backend/src/main/resources/logback/access-logger.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<included>
+  <property name="home" value="logs/access/"/>
+  <appender name="access-logger-file" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <file>${home}access.log</file>
+    <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+      <fileNamePattern>${home}access-%d{yyyyMMdd}-%i.log</fileNamePattern>
+      <timeBasedFileNamingAndTriggeringPolicy
+        class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
+        <maxFileSize>15MB</maxFileSize>
+      </timeBasedFileNamingAndTriggeringPolicy>
+      <maxHistory>7</maxHistory>
+    </rollingPolicy>
+    <encoder>
+      <charset>utf8</charset>
+      <Pattern>
+        %n###### HTTP Request ###### %n%fullRequest###### HTTP Response ###### %n%fullResponse
+      </Pattern>
+    </encoder>
+  </appender>
+</included>

--- a/backend/src/main/resources/logback/console-access-logger.xml
+++ b/backend/src/main/resources/logback/console-access-logger.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<included>
+  <appender name="console-access-logger" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <charset>utf8</charset>
+      <pattern>
+        %n###### HTTP Request ###### %n%fullRequest###### HTTP Response ###### %n%fullResponse
+      </pattern>
+    </encoder>
+  </appender>
+</included>

--- a/backend/src/main/resources/logback/console-logger.xml
+++ b/backend/src/main/resources/logback/console-logger.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<included>
+  <appender name="console-logger" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <charset>utf8</charset>
+      <Pattern>
+        %cyan(%d{yyyy-MM-dd HH:mm:ss}:%-4relative) %highlight(%-5level) %yellow([%C.%M]:%boldWhite(%L)]) %n    > %msg%n
+      </Pattern>
+    </encoder>
+  </appender>
+
+  <appender name="db-logger-console" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <charset>utf8</charset>
+      <Pattern>
+        %green(    > %msg%n)
+      </Pattern>
+    </encoder>
+  </appender>
+</included>

--- a/backend/src/main/resources/logback/debug-logger.xml
+++ b/backend/src/main/resources/logback/debug-logger.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<included>
+  <property name="home" value="logs/debug/"/>
+  <appender name="debug-logger-file" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <file>${home}info.log</file>
+    <filter class="ch.qos.logback.classic.filter.LevelFilter">
+      <level>DEBUG</level>
+      <onMatch>ACCEPT</onMatch>
+      <onMismatch>DENY</onMismatch>
+    </filter>
+    <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+      <fileNamePattern>${home}info-%d{yyyyMMdd}-%i.log</fileNamePattern>
+      <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
+        <maxFileSize>15MB</maxFileSize>
+      </timeBasedFileNamingAndTriggeringPolicy>
+      <maxHistory>7</maxHistory>
+    </rollingPolicy>
+    <encoder>
+      <charset>utf8</charset>
+      <Pattern>
+        %d{yyyy-MM-dd HH:mm:ss}:%-4relative %-5level [%C.%M]:%L] %n    > %msg%n
+      </Pattern>
+    </encoder>
+  </appender>
+</included>

--- a/backend/src/main/resources/logback/error-logger.xml
+++ b/backend/src/main/resources/logback/error-logger.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<included>
+  <property name="home" value="logs/error/"/>
+  <appender name="error-logger-file" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <file>${home}error.log</file>
+    <filter class="ch.qos.logback.classic.filter.LevelFilter">
+      <level>ERROR</level>
+      <onMatch>ACCEPT</onMatch>
+      <onMismatch>DENY</onMismatch>
+    </filter>
+    <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+      <fileNamePattern>${home}error-%d{yyyyMMdd}-%i.log</fileNamePattern>
+      <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
+        <maxFileSize>15MB</maxFileSize>
+      </timeBasedFileNamingAndTriggeringPolicy>
+      <maxHistory>7</maxHistory>
+    </rollingPolicy>
+    <encoder>
+      <charset>utf8</charset>
+      <Pattern>
+        %d{yyyy-MM-dd HH:mm:ss}:%-4relative %-5level [%C.%M]:%L] %n    > %msg%n
+      </Pattern>
+    </encoder>
+  </appender>
+</included>

--- a/backend/src/main/resources/logback/info-logger.xml
+++ b/backend/src/main/resources/logback/info-logger.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<included>
+  <property name="home" value="logs/info/"/>
+  <appender name="info-logger-file" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <file>${home}info.log</file>
+    <filter class="ch.qos.logback.classic.filter.LevelFilter">
+      <level>INFO</level>
+      <onMatch>ACCEPT</onMatch>
+      <onMismatch>DENY</onMismatch>
+    </filter>
+    <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+      <fileNamePattern>${home}info-%d{yyyyMMdd}-%i.log</fileNamePattern>
+      <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
+        <maxFileSize>15MB</maxFileSize>
+      </timeBasedFileNamingAndTriggeringPolicy>
+      <maxHistory>7</maxHistory>
+    </rollingPolicy>
+    <encoder>
+      <charset>utf8</charset>
+      <Pattern>
+        %d{yyyy-MM-dd HH:mm:ss}:%-4relative %-5level [%C.%M]:%L] %n    > %msg%n
+      </Pattern>
+    </encoder>
+  </appender>
+</included>

--- a/backend/src/main/resources/logback/warn-logger.xml
+++ b/backend/src/main/resources/logback/warn-logger.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<included>
+  <property name="home" value="logs/warn/"/>
+  <appender name="warn-logger-file" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <file>${home}warn.log</file>
+    <filter class="ch.qos.logback.classic.filter.LevelFilter">
+      <level>WARN</level>
+      <onMatch>ACCEPT</onMatch>
+      <onMismatch>DENY</onMismatch>
+    </filter>
+    <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+      <fileNamePattern>${home}warn-%d{yyyyMMdd}-%i.log</fileNamePattern>
+      <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
+        <maxFileSize>15MB</maxFileSize>
+      </timeBasedFileNamingAndTriggeringPolicy>
+      <maxHistory>30</maxHistory>
+    </rollingPolicy>
+    <encoder>
+      <charset>utf8</charset>
+      <Pattern>
+        %d{yyyy-MM-dd HH:mm:ss}:%-4relative %-5level [%C.%M]:%L] %n    > %msg%n
+      </Pattern>
+    </encoder>
+  </appender>
+</included>


### PR DESCRIPTION
## 로깅 전략

### PORD

- **프로덕션(wooteco.prolog)**
  - ERROR Level 로깅 (콘솔, 파일)
- **스프링 프레임워크(org.springframwork)**
  - INFO Level 로깅 (콘솔, 파일)

### DEV

- **프로덕션(wooteco.prolog)**
  - DEBUG Level 로깅 (콘솔, 파일)
- **스프링 프레임워크(org.springframwork)**
  - INFO Level 로깅 (콘솔, 파일)

### LOCAL AND TEST

- **프로덕션(wooteco.prolog)**
  - DEBUG Level 로깅 (콘솔)
- **스프링 프레임워크(org.springframwork)**
  - INFO Level 로깅 (콘솔)
- **SQL 출력(org.hibernate,SQL)**
  - DEBUG Level 로깅 (콘솔)
- **Binding parameter (org.hibernate.type.descriptor.sql.BasicBinder)**
  - TRACE Level 로깅 (콘솔)
- **Select result (org.hibernate.type.descriptor.sql.BasicExtractor)**
  - TRACE Level 로깅 (콘솔)

## 로그 파일 디렉터리 구조

```
access  debug   error   info    warn
```

## RollingFileAppender 전략

- 시간 및 로그 파일 크기 기반
  - 15MB 
  - 7일


## 소스 변경 사항
```
public class ExceptionController {

    @ExceptionHandler(BadRequestException.class)
    public ResponseEntity<ExceptionDto> loginExceptionHandler(BadRequestException e) {
        log.warn(e.getMessage());
        return ResponseEntity.badRequest()
                .body(new ExceptionDto(e.getCode(), e.getMessage()));
    }

    @ExceptionHandler(Exception.class)
    public ResponseEntity<ExceptionDto> runtimeExceptionHandler(Exception e) {
        log.error(e.getMessage());
        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
            .body(new ExceptionDto(500, "알 수 없는 에러"));
    }
}
```

ExceptionController에 logger가 추가되었으며, 예상하지 못한 예외에 대하여 500에러와 함께 알 수 없는 에러를 내보내도록 변경하였습니다
** 이 부분에 대하여 논의가 필요합니다 (예상할 수 없는 예외) **


close #336 