### PR TITLE
fix: 글 추가 페이지에서 제목이 잘리는 버그 수정

### DIFF
--- a/frontend/src/components/Card/EditPostCard.js
+++ b/frontend/src/components/Card/EditPostCard.js
@@ -6,6 +6,7 @@ import { Editor } from '@toast-ui/react-editor';
 
 import 'codemirror/lib/codemirror.css';
 import '@toast-ui/editor/dist/toastui-editor.css';
+import { POST_TITLE } from '../../constants';
 
 const TitleInput = styled.input`
   width: 100%;
@@ -45,6 +46,9 @@ const EditPostCard = forwardRef(({ post, tagOptions }, ref) => {
     <Card size={CARD_SIZE.LARGE}>
       <TitleInput
         placeholder="제목을 입력해주세요"
+        required
+        minLength={POST_TITLE.MIN_LENGTH}
+        maxLength={POST_TITLE.MAX_LENGTH}
         autoFocus
         ref={(element) => assignRefValue('title', element)}
         defaultValue={title}

--- a/frontend/src/components/Card/NewPostCard.styles.js
+++ b/frontend/src/components/Card/NewPostCard.styles.js
@@ -3,11 +3,11 @@ import COLOR from '../../constants/color';
 
 const TitleInput = styled.input`
   width: 100%;
-  height: 3rem;
+  height: 5.4rem;
   padding: 0;
   margin: 1rem 0;
 
-  font-size: 3.4rem;
+  font-size: 4.4rem;
   font-weight: 700;
 
   border: none;


### PR DESCRIPTION
closes #296 

height가 너무 낮게 설정되어 있어서 발생한 버그였습니다. 글 수정 페이지와 같게 유지해 버그를 수정했습니다.
(사파리에서 테스트는 못해봤는데 이슈는 없을 것 같습니다.)

그리고 글 수정 페이지에서 require같은 속성이 글 추가 페이지와 달라서 동일하게 유지시켰습니다.