### PR TITLE
fix: 제목이 길어질 시 닉네임이 잘리는 버그 수정

### DIFF
--- a/frontend/src/pages/MainPage/styles.js
+++ b/frontend/src/pages/MainPage/styles.js
@@ -29,10 +29,12 @@ const SelectedFilterList = styled.div`
 const PostListContainer = styled.div`
   display: grid;
   grid-row-gap: 2rem;
+  word-break: break-all;
 `;
 
 const Content = styled.div`
   display: flex;
+  justify-content: space-between;
   height: 100%;
 `;
 
@@ -60,7 +62,8 @@ const Tags = styled.div`
 `;
 
 const ProfileChipLocationStyle = css`
-  margin-left: auto;
+  flex-shrink: 0;
+  margin-left: 1rem;
 
   &:hover {
     background-color: ${COLOR.LIGHT_BLUE_100};

--- a/frontend/src/pages/MainPage/styles.js
+++ b/frontend/src/pages/MainPage/styles.js
@@ -16,9 +16,10 @@ const FilterListWrapper = styled.div`
 
 const SelectedFilterList = styled.div`
   width: 100%;
-  height: 3rem;
-  overflow: scroll;
+  min-height: 3rem;
+  overflow: auto;
   margin-top: 1rem;
+  padding-bottom: 1rem;
 
   ul {
     width: max-content;


### PR DESCRIPTION
제목이 길어졌을 때 닉네임이 잘리는 버그를 수정했습니다.
스타일 코드만 살짝 건들였어요!

그리고 필터링 화면이 살짝 잘리는 것 같아서 이것도 같이 수정했습니다.

제목 수정 전
![image](https://user-images.githubusercontent.com/43840561/130416886-793fc3c2-8163-4853-bf53-0890611dd2d4.png)

제목 수정 후
![image](https://user-images.githubusercontent.com/64782636/132699610-4e384cee-ddbb-438b-886e-4d581f89265b.png)
![image](https://user-images.githubusercontent.com/64782636/132699660-94035bfc-d84e-4c4b-8455-2b99d258e85e.png)

필터링 수정 전
![image](https://user-images.githubusercontent.com/64782636/132701383-4d4807bd-6231-4c75-af1d-f7a53d89c626.png)

필터링 수정 후
![image](https://user-images.githubusercontent.com/64782636/132701570-e148a7dd-a24d-4800-b469-a10b623eee64.png)
