### PR TITLE
학습로그 목록 조회 시 필요한 쿼리 스트링 변경

### DIFF
--- a/backend/src/main/java/wooteco/prolog/studylog/application/dto/search/SearchArgumentResolver.java
+++ b/backend/src/main/java/wooteco/prolog/studylog/application/dto/search/SearchArgumentResolver.java
@@ -86,7 +86,7 @@ public class SearchArgumentResolver implements HandlerMethodArgumentResolver {
 
     private Pageable makePageableDefault(NativeWebRequest webRequest) {
         int page = convertToInt(webRequest, "page", 1) - 1;
-        int size = convertToInt(webRequest, "size", 20);
+        int size = convertToInt(webRequest, "size", 10);
         return PageRequest.of(
             page,
             size,

--- a/frontend/src/hooks/useFilterWithParams.js
+++ b/frontend/src/hooks/useFilterWithParams.js
@@ -17,9 +17,7 @@ const useFilterWithParams = () => {
   ]);
 
   const [postQueryParams, setPostQueryParams] = useState({
-    page: query.page ?? 1,
-    size: query.size ?? 10,
-    direction: query.direction ?? 'desc',
+    page: query.page ? query.page : 1,
   });
 
   const onSetPage = (page) => {
@@ -40,14 +38,22 @@ const useFilterWithParams = () => {
       (filter) => !(filter.filterType === filterType && filter.filterDetailId === filterDetailId)
     );
 
+    setPostQueryParams({ ...postQueryParams, page: 1 });
     setSelectedFilterDetails(newFilters);
   };
 
   const getFullParams = useCallback(() => {
+    if (postQueryParams.page == 1) {
+      delete postQueryParams.page
+    }
+
     const pageParams = queryString.stringify(postQueryParams);
-    const filterParams = selectedFilterDetails
-      .map((filter) => `${filter.filterType}=${filter.filterDetailId}`)
-      .join('&');
+    const filterParams =
+      selectedFilterDetails.length > 0
+        ? selectedFilterDetails
+            .map((filter) => `${filter.filterType}=${filter.filterDetailId}`)
+            .join('&')
+        : '';
 
     return `${pageParams}${filterParams ? `&${filterParams}` : ''}`;
   }, [postQueryParams, selectedFilterDetails]);

--- a/frontend/src/pages/MainPage/index.js
+++ b/frontend/src/pages/MainPage/index.js
@@ -80,8 +80,16 @@ const MainPage = () => {
   useEffect(() => {
     const params = getFullParams();
 
-    history.push(`${PATH.ROOT}?${search ? 'keyword=' + search : ''}&${params ?? ''}`);
-  }, [selectedFilterDetails, postQueryParams, getFullParams]);
+    if (!search && !params) {
+      history.push(`${PATH.ROOT}`);
+    } else if (params && !search) {
+      history.push(`${PATH.ROOT}?${params ? params : ''}`);
+    } else if (search && !params) {
+      history.push(`${PATH.ROOT}?${search ? 'keyword=' + search : ''}`);
+    } else {
+      history.push(`${PATH.ROOT}?${search ? 'keyword=' + search : ''}&${params ?? ''}`);
+    }
+  }, [getFullParams, postQueryParams, selectedFilterDetails]);
 
   useEffect(() => {
     const getData = async () => {

--- a/frontend/src/pages/ProfilePagePosts/index.js
+++ b/frontend/src/pages/ProfilePagePosts/index.js
@@ -66,7 +66,7 @@ const ProfilePagePosts = () => {
   };
 
   const getData = async () => {
-    const query = new URLSearchParams(history.location.search);
+    const query = new URLSearchParams(history.location.search) + `&usernames=${username}`;
 
     try {
       const response = await requestGetPosts({ type: 'searchParams', data: query });
@@ -95,12 +95,9 @@ const ProfilePagePosts = () => {
 
   useEffect(() => {
     const params = getFullParams();
-    const search = new URLSearchParams(history.location.search).get('keyword');
 
-    history.push(
-      `${PATH.ROOT}${username}/posts?${search ? 'keyword=' + search : ''}&${params ?? ''}&${
-        username ? 'usernames=' + username : ''
-      }`
+    history.replace(
+      `${PATH.ROOT}${username}/posts${params ? '?'+params : ''}`
     );
   }, [getFullParams, postQueryParams, selectedFilterDetails, username]);
 

--- a/frontend/src/pages/ProfilePagePosts/index.js
+++ b/frontend/src/pages/ProfilePagePosts/index.js
@@ -96,9 +96,11 @@ const ProfilePagePosts = () => {
   useEffect(() => {
     const params = getFullParams();
 
-    history.replace(
-      `${PATH.ROOT}${username}/posts${params ? '?'+params : ''}`
-    );
+    if (!params) {
+      return;
+    }
+
+    history.push(`${PATH.ROOT}${username}/posts${params ? '?' + params : ''}`);
   }, [getFullParams, postQueryParams, selectedFilterDetails, username]);
 
   useEffect(() => {


### PR DESCRIPTION
## 버그 픽스
- #377 

## 변경 사항
- 사이즈와 정렬은 쿼리 스트링에서 제거한다
- 첫 페이지 시 page=1 쿼리 스트링을 제거한다.
- 필터를 제거했을 때 첫 페이지로 이동한다
- 프로필 > 포스트usernames를 쿼리스트링에서 제거한다.
