### PR TITLE
오버뷰 페이지에서 태그/달력 선택 시 페이지 초기화가 되지 않는 버그 수정

### DIFF
--- a/frontend/src/pages/ProfilePage/index.js
+++ b/frontend/src/pages/ProfilePage/index.js
@@ -52,6 +52,7 @@ const ProfilePage = ({ children, menu }) => {
         ...filteringOption,
         { filterType: 'usernames', filterDetailId: username },
       ];
+
       const response = await requestGetPosts({
         type: 'filter',
         data: { filterQuery, postQueryParams },
@@ -136,6 +137,7 @@ const ProfilePage = ({ children, menu }) => {
                     onClick={() => {
                       setSelectedTagId(id);
                       setSelectedDay(-1);
+                      onSetPage(1);
                       setFilteringOptionWithTagId(id);
                     }}
                   />
@@ -147,6 +149,7 @@ const ProfilePage = ({ children, menu }) => {
                 newDate={state?.date}
                 onClick={(year, month, day) => {
                   setSelectedTagId(null);
+                  onSetPage(1);
                   setFilteringOptionWithDate(year, month, day);
                 }}
                 selectedDay={selectedDay}

--- a/frontend/src/service/requests.js
+++ b/frontend/src/service/requests.js
@@ -20,7 +20,7 @@ const requestGetPosts = (query) => {
           ({ filterType, filterDetailId }) => `${filterType}=${filterDetailId}`
         )
       : '';
-    console.log(searchParams, filterQuery);
+
     return fetch(`${BASE_URL}/posts?${[...filterQuery, ...searchParams].join('&')}`);
   }
 };


### PR DESCRIPTION
#394 

태그/ 달력을 선택했을 때 이전 페이지가 그대로 전달되고 있어서 생긴 버그였습니다.
해결 완료!