### PR TITLE
다른 사람의 닉네임을 수정할 수 있는 버그 해결

### DIFF
--- a/frontend/src/components/ProfilePageSideBar/ProfilePageSideBar.js
+++ b/frontend/src/components/ProfilePageSideBar/ProfilePageSideBar.js
@@ -26,6 +26,7 @@ const ProfilePageSideBar = ({ menu }) => {
   const history = useHistory();
   const { username } = useParams();
   const accessToken = useSelector((state) => state.user.accessToken.data);
+  const myName = useSelector((state) => state.user.profile.data?.username);
 
   const [user, setUser] = useState({});
   const [selectedMenu, setSelectedMenu] = useState('');
@@ -112,17 +113,19 @@ const ProfilePageSideBar = ({ menu }) => {
           ) : (
             <Nickname>{user?.nickname}</Nickname>
           )}
-          <Button
-            size={BUTTON_SIZE.X_SMALL}
-            type="button"
-            css={EditButtonStyle}
-            alt={isProfileEditing ? '수정 완료 버튼' : '수정 버튼'}
-            onClick={() => {
-              isProfileEditing ? editProfile() : setIsProfileEditing(true);
-            }}
-          >
-            {isProfileEditing ? '완료' : '수정'}
-          </Button>
+          {myName === username && (
+            <Button
+              size={BUTTON_SIZE.X_SMALL}
+              type="button"
+              css={EditButtonStyle}
+              alt={isProfileEditing ? '수정 완료 버튼' : '수정 버튼'}
+              onClick={() => {
+                isProfileEditing ? editProfile() : setIsProfileEditing(true);
+              }}
+            >
+              {isProfileEditing ? '완료' : '수정'}
+            </Button>
+          )}
         </NicknameWrapper>
       </Profile>
       <MenuList>

--- a/frontend/src/components/ProfilePageSideBar/ProfilePageSideBar.js
+++ b/frontend/src/components/ProfilePageSideBar/ProfilePageSideBar.js
@@ -71,8 +71,8 @@ const ProfilePageSideBar = ({ menu }) => {
   const editProfile = async () => {
     if (nickname === user.nickname) return setIsProfileEditing(false);
 
-    if (nickname.length > 20) {
-      alert('닉네임은 20글자 이하로 입력해주세요.');
+    if (nickname.length > 4) {
+      alert('닉네임은 4글자 이하로 입력해주세요.');
 
       return;
     }


### PR DESCRIPTION
다른 사람의 닉네임도 수정할 수 있는 버그를 발견해 해결했습니다.

이제는 자신의 프로필이 아니라면 수정 버튼이 보이지 않습니다.