### PR TITLE
refactor: ArgumentResolver 에서 서비스 직접 참조 끊고 LoginMember Dto 로 변환

### DIFF
--- a/backend/src/main/java/wooteco/prolog/DataLoaderApplicationListener.java
+++ b/backend/src/main/java/wooteco/prolog/DataLoaderApplicationListener.java
@@ -9,6 +9,8 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 import org.springframework.context.event.ContextRefreshedEvent;
 import wooteco.prolog.login.application.dto.GithubProfileResponse;
+import wooteco.prolog.login.ui.LoginMember;
+import wooteco.prolog.login.ui.LoginMember.Authority;
 import wooteco.prolog.member.application.MemberService;
 import wooteco.prolog.member.domain.Member;
 import wooteco.prolog.studylog.application.DocumentService;
@@ -92,7 +94,7 @@ public class DataLoaderApplicationListener implements
                                                           "https://avatars.githubusercontent.com/u/48412963?v=4"));
 
         // post init
-        studylogService.insertStudylogs(member1, Arrays.asList(
+        studylogService.insertStudylogs(member1.getId(), Arrays.asList(
             new StudylogRequest("ATDD란 무엇인가", "노션 정리 링크\n개인적으로 친구들에게 한 설명이 참 잘 썼다고 생각한다 호호",
                                 mission1.getId(), tagRequests_1234),
             new StudylogRequest("프론트엔드 빌드 툴", "snowpack 사용하기 https://hjuu.tistory.com/6",
@@ -105,7 +107,7 @@ public class DataLoaderApplicationListener implements
             new StudylogRequest("페이지네이션 데이터 6", "좋은 내용", mission2.getId(), tagRequests_1234)
         ));
 
-        studylogService.insertStudylogs(member2, Arrays.asList(
+        studylogService.insertStudylogs(member2.getId(), Arrays.asList(
             new StudylogRequest("페이지네이션 데이터 7", "좋은 내용", mission3.getId(), tagRequests_empty),
             new StudylogRequest("페이지네이션 데이터 8", "좋은 내용", mission4.getId(), tagRequests_12),
             new StudylogRequest("페이지네이션 데이터 9", "좋은 내용", mission1.getId(), tagRequests_34),
@@ -115,6 +117,5 @@ public class DataLoaderApplicationListener implements
         ));
 
         updatedContentsRepository.save(new UpdatedContents(null, UpdateContent.MEMBER_TAG_UPDATE, 1));
-
     }
 }

--- a/backend/src/main/java/wooteco/prolog/login/aop/LoginMemberVerifier.java
+++ b/backend/src/main/java/wooteco/prolog/login/aop/LoginMemberVerifier.java
@@ -12,14 +12,14 @@ import wooteco.prolog.member.exception.MemberNotAllowedException;
 @Component
 public class LoginMemberVerifier {
 
-    @Before("@annotation(OnlyMember)")
-    public void checkTime(JoinPoint joinPoint) {
+    @Before("@annotation(wooteco.prolog.login.aop.MemberOnly)")
+    public void checkLoginMember(JoinPoint joinPoint) {
         final LoginMember loginMember = (LoginMember) Arrays.stream(joinPoint.getArgs())
             .filter(argument -> argument instanceof LoginMember)
             .findAny()
             .orElseThrow(() -> new IllegalStateException("LoginMember 가 존재하지 않습니다."));
-        if (loginMember.isAnonymous()) {
-            throw new MemberNotAllowedException();
-        }
+
+        loginMember.act()
+            .throwIfAnonymous(MemberNotAllowedException::new);
     }
 }

--- a/backend/src/main/java/wooteco/prolog/login/aop/LoginMemberVerifier.java
+++ b/backend/src/main/java/wooteco/prolog/login/aop/LoginMemberVerifier.java
@@ -1,0 +1,25 @@
+package wooteco.prolog.login.aop;
+
+import java.util.Arrays;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.springframework.stereotype.Component;
+import wooteco.prolog.login.ui.LoginMember;
+import wooteco.prolog.member.exception.MemberNotAllowedException;
+
+@Aspect
+@Component
+public class LoginMemberVerifier {
+
+    @Before("@annotation(OnlyMember)")
+    public void checkTime(JoinPoint joinPoint) {
+        final LoginMember loginMember = (LoginMember) Arrays.stream(joinPoint.getArgs())
+            .filter(argument -> argument instanceof LoginMember)
+            .findAny()
+            .orElseThrow(() -> new IllegalStateException("LoginMember 가 존재하지 않습니다."));
+        if (loginMember.isAnonymous()) {
+            throw new MemberNotAllowedException();
+        }
+    }
+}

--- a/backend/src/main/java/wooteco/prolog/login/aop/MemberOnly.java
+++ b/backend/src/main/java/wooteco/prolog/login/aop/MemberOnly.java
@@ -7,6 +7,6 @@ import java.lang.annotation.Target;
 
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
-public @interface OnlyMember {
+public @interface MemberOnly {
 
 }

--- a/backend/src/main/java/wooteco/prolog/login/aop/OnlyMember.java
+++ b/backend/src/main/java/wooteco/prolog/login/aop/OnlyMember.java
@@ -1,0 +1,12 @@
+package wooteco.prolog.login.aop;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface OnlyMember {
+
+}

--- a/backend/src/main/java/wooteco/prolog/login/ui/AuthMemberPrincipalArgumentResolver.java
+++ b/backend/src/main/java/wooteco/prolog/login/ui/AuthMemberPrincipalArgumentResolver.java
@@ -27,11 +27,10 @@ public class AuthMemberPrincipalArgumentResolver implements HandlerMethodArgumen
     @Override
     public LoginMember resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
                                   NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
-
         String credentials = AuthorizationExtractor
             .extract(webRequest.getNativeRequest(HttpServletRequest.class));
 
-        if (!jwtTokenProvider.validateToken(credentials)) {
+        if (credentials == null || credentials.isEmpty()) {
             return new LoginMember(Authority.ANONYMOUS);
         }
 

--- a/backend/src/main/java/wooteco/prolog/login/ui/LoginMember.java
+++ b/backend/src/main/java/wooteco/prolog/login/ui/LoginMember.java
@@ -1,0 +1,28 @@
+package wooteco.prolog.login.ui;
+
+public class LoginMember {
+
+    public enum Authority {
+        ANONYMOUS, MEMBER
+    }
+
+    private Long id;
+    private Authority authority;
+
+    public LoginMember(Authority authority) {
+        this(null, authority);
+    }
+
+    public LoginMember(Long id, Authority authority) {
+        this.id = id;
+        this.authority = authority;
+    }
+
+    public boolean isAnonymous() {
+        return authority.equals(Authority.ANONYMOUS);
+    }
+
+    public Long getId() {
+        return id;
+    }
+}

--- a/backend/src/main/java/wooteco/prolog/login/ui/LoginMember.java
+++ b/backend/src/main/java/wooteco/prolog/login/ui/LoginMember.java
@@ -1,5 +1,8 @@
 package wooteco.prolog.login.ui;
 
+import java.util.function.Function;
+import java.util.function.Supplier;
+
 public class LoginMember {
 
     public enum Authority {
@@ -19,10 +22,54 @@ public class LoginMember {
     }
 
     public boolean isAnonymous() {
-        return authority.equals(Authority.ANONYMOUS);
+        return Authority.ANONYMOUS.equals(authority);
+    }
+
+    private boolean isMember() {
+        return Authority.MEMBER.equals(authority);
     }
 
     public Long getId() {
         return id;
+    }
+
+    public UserAction act() {
+        return new UserAction(this);
+    }
+
+    public static class UserAction {
+
+        private final LoginMember loginMember;
+        private Object returnValue;
+
+        public UserAction(LoginMember loginMember) {
+            this.loginMember = loginMember;
+        }
+
+        public UserAction ifAnonymous(Supplier<?> supplier) {
+            if (loginMember.isAnonymous()) {
+                this.returnValue = supplier.get();
+            }
+            return this;
+        }
+
+        public <T extends Throwable> UserAction throwIfAnonymous(Supplier<? extends T> supplier)
+            throws T {
+            if (loginMember.isAnonymous()) {
+                throw supplier.get();
+            }
+            return this;
+        }
+
+        public UserAction ifMember(Function<Long, ?> function) {
+            if (loginMember.isMember()) {
+                this.returnValue = function.apply(loginMember.getId());
+            }
+            return this;
+        }
+
+        public Object getReturnValue() {
+            return returnValue;
+        }
     }
 }

--- a/backend/src/main/java/wooteco/prolog/login/ui/LoginMember.java
+++ b/backend/src/main/java/wooteco/prolog/login/ui/LoginMember.java
@@ -71,5 +71,10 @@ public class LoginMember {
         public Object getReturnValue() {
             return returnValue;
         }
+
+        @SuppressWarnings("unchecked")
+        public <T> T getReturnValue(Class<T> returnType) {
+            return (T) returnValue;
+        }
     }
 }

--- a/backend/src/main/java/wooteco/prolog/member/application/MemberService.java
+++ b/backend/src/main/java/wooteco/prolog/member/application/MemberService.java
@@ -6,6 +6,7 @@ import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import wooteco.prolog.login.application.dto.GithubProfileResponse;
+import wooteco.prolog.login.ui.LoginMember;
 import wooteco.prolog.member.application.dto.MemberResponse;
 import wooteco.prolog.member.application.dto.MemberUpdateRequest;
 import wooteco.prolog.member.domain.Member;
@@ -41,8 +42,8 @@ public class MemberService {
     }
 
     @Transactional
-    public void updateMember(Member member, MemberUpdateRequest updateRequest) {
-        Member persistMember = findByUsername(member.getUsername());
+    public void updateMember(Long memberId, MemberUpdateRequest updateRequest) {
+        Member persistMember = findById(memberId);
         persistMember.updateImageUrl(updateRequest.getImageUrl());
         persistMember.updateNickname(updateRequest.getNickname());
     }

--- a/backend/src/main/java/wooteco/prolog/member/ui/MemberController.java
+++ b/backend/src/main/java/wooteco/prolog/member/ui/MemberController.java
@@ -9,13 +9,12 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import wooteco.prolog.login.aop.OnlyMember;
+import wooteco.prolog.login.aop.MemberOnly;
 import wooteco.prolog.login.domain.AuthMemberPrincipal;
 import wooteco.prolog.login.ui.LoginMember;
 import wooteco.prolog.member.application.MemberService;
 import wooteco.prolog.member.application.dto.MemberResponse;
 import wooteco.prolog.member.application.dto.MemberUpdateRequest;
-import wooteco.prolog.member.domain.Member;
 
 @RestController
 @AllArgsConstructor
@@ -25,7 +24,7 @@ public class MemberController {
     private MemberService memberService;
 
     @GetMapping(value = "/me", produces = MediaType.APPLICATION_JSON_VALUE)
-    @OnlyMember
+    @MemberOnly
     public ResponseEntity<MemberResponse> findMemberInfoOfMine(@AuthMemberPrincipal LoginMember member) {
         return ResponseEntity.ok().body(MemberResponse.of(memberService.findById(member.getId())));
     }
@@ -36,7 +35,7 @@ public class MemberController {
     }
 
     @PutMapping("/me")
-    @OnlyMember
+    @MemberOnly
     public ResponseEntity<Void> updateStudylog(
         @AuthMemberPrincipal LoginMember member,
         @RequestBody MemberUpdateRequest updateRequest

--- a/backend/src/main/java/wooteco/prolog/member/ui/MemberController.java
+++ b/backend/src/main/java/wooteco/prolog/member/ui/MemberController.java
@@ -4,11 +4,14 @@ import lombok.AllArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import wooteco.prolog.login.aop.OnlyMember;
 import wooteco.prolog.login.domain.AuthMemberPrincipal;
+import wooteco.prolog.login.ui.LoginMember;
 import wooteco.prolog.member.application.MemberService;
 import wooteco.prolog.member.application.dto.MemberResponse;
 import wooteco.prolog.member.application.dto.MemberUpdateRequest;
@@ -22,21 +25,23 @@ public class MemberController {
     private MemberService memberService;
 
     @GetMapping(value = "/me", produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<MemberResponse> findMemberInfoOfMine(@AuthMemberPrincipal Member member) {
-        return ResponseEntity.ok().body(MemberResponse.of(member));
+    @OnlyMember
+    public ResponseEntity<MemberResponse> findMemberInfoOfMine(@AuthMemberPrincipal LoginMember member) {
+        return ResponseEntity.ok().body(MemberResponse.of(memberService.findById(member.getId())));
     }
 
     @GetMapping(value = "/{username}", produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<MemberResponse> findMemberInfo(@AuthMemberPrincipal Member member) {
-        return ResponseEntity.ok().body(MemberResponse.of(member));
+    public ResponseEntity<MemberResponse> findMemberInfo(@PathVariable String username) {
+        return ResponseEntity.ok().body(MemberResponse.of(memberService.findByUsername(username)));
     }
 
     @PutMapping("/me")
+    @OnlyMember
     public ResponseEntity<Void> updateStudylog(
-        @AuthMemberPrincipal Member member,
+        @AuthMemberPrincipal LoginMember member,
         @RequestBody MemberUpdateRequest updateRequest
     ) {
-        memberService.updateMember(member, updateRequest);
+        memberService.updateMember(member.getId(), updateRequest);
         return ResponseEntity.ok().build();
     }
 }

--- a/backend/src/main/java/wooteco/prolog/studylog/ui/StudylogController.java
+++ b/backend/src/main/java/wooteco/prolog/studylog/ui/StudylogController.java
@@ -11,10 +11,9 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import wooteco.prolog.login.aop.OnlyMember;
+import wooteco.prolog.login.aop.MemberOnly;
 import wooteco.prolog.login.domain.AuthMemberPrincipal;
 import wooteco.prolog.login.ui.LoginMember;
-import wooteco.prolog.member.domain.Member;
 import wooteco.prolog.studylog.application.StudylogService;
 import wooteco.prolog.studylog.application.dto.StudylogRequest;
 import wooteco.prolog.studylog.application.dto.StudylogResponse;
@@ -35,7 +34,7 @@ public class StudylogController {
     }
 
     @PostMapping
-    @OnlyMember
+    @MemberOnly
     public ResponseEntity<Void> createStudylog(@AuthMemberPrincipal LoginMember member,
                                                @RequestBody List<StudylogRequest> studylogRequests) {
         List<StudylogResponse> studylogResponse = studylogService
@@ -60,7 +59,7 @@ public class StudylogController {
     }
 
     @PutMapping("/{id}")
-    @OnlyMember
+    @MemberOnly
     public ResponseEntity<Void> updateStudylog(
         @AuthMemberPrincipal LoginMember member,
         @PathVariable Long id,
@@ -71,7 +70,7 @@ public class StudylogController {
     }
 
     @DeleteMapping("/{id}")
-    @OnlyMember
+    @MemberOnly
     public ResponseEntity<Void> deleteStudylog(@AuthMemberPrincipal LoginMember member,
                                                @PathVariable Long id) {
         studylogService.deleteStudylog(member.getId(), id);

--- a/backend/src/main/java/wooteco/prolog/studylog/ui/StudylogController.java
+++ b/backend/src/main/java/wooteco/prolog/studylog/ui/StudylogController.java
@@ -11,7 +11,9 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import wooteco.prolog.login.aop.OnlyMember;
 import wooteco.prolog.login.domain.AuthMemberPrincipal;
+import wooteco.prolog.login.ui.LoginMember;
 import wooteco.prolog.member.domain.Member;
 import wooteco.prolog.studylog.application.StudylogService;
 import wooteco.prolog.studylog.application.dto.StudylogRequest;
@@ -33,10 +35,11 @@ public class StudylogController {
     }
 
     @PostMapping
-    public ResponseEntity<Void> createStudylog(@AuthMemberPrincipal Member member,
+    @OnlyMember
+    public ResponseEntity<Void> createStudylog(@AuthMemberPrincipal LoginMember member,
                                                @RequestBody List<StudylogRequest> studylogRequests) {
         List<StudylogResponse> studylogResponse = studylogService
-            .insertStudylogs(member, studylogRequests);
+            .insertStudylogs(member.getId(), studylogRequests);
         return ResponseEntity.created(URI.create("/posts/" + studylogResponse.get(0).getId()))
             .build();
     }
@@ -57,19 +60,21 @@ public class StudylogController {
     }
 
     @PutMapping("/{id}")
+    @OnlyMember
     public ResponseEntity<Void> updateStudylog(
-        @AuthMemberPrincipal Member member,
+        @AuthMemberPrincipal LoginMember member,
         @PathVariable Long id,
         @RequestBody StudylogRequest studylogRequest
     ) {
-        studylogService.updateStudylog(member, id, studylogRequest);
+        studylogService.updateStudylog(member.getId(), id, studylogRequest);
         return ResponseEntity.ok().build();
     }
 
     @DeleteMapping("/{id}")
-    public ResponseEntity<Void> deleteStudylog(@AuthMemberPrincipal Member member,
+    @OnlyMember
+    public ResponseEntity<Void> deleteStudylog(@AuthMemberPrincipal LoginMember member,
                                                @PathVariable Long id) {
-        studylogService.deleteStudylog(member, id);
+        studylogService.deleteStudylog(member.getId(), id);
         return ResponseEntity.noContent().build();
     }
 }

--- a/backend/src/test/java/wooteco/prolog/member/application/MemberServiceTest.java
+++ b/backend/src/test/java/wooteco/prolog/member/application/MemberServiceTest.java
@@ -8,6 +8,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
 import wooteco.prolog.login.application.dto.GithubProfileResponse;
+import wooteco.prolog.login.ui.LoginMember;
+import wooteco.prolog.login.ui.LoginMember.Authority;
 import wooteco.prolog.member.application.dto.MemberResponse;
 import wooteco.prolog.member.application.dto.MemberUpdateRequest;
 import wooteco.prolog.member.domain.Member;
@@ -132,7 +134,7 @@ class MemberServiceTest {
         MemberUpdateRequest updateRequest = new MemberUpdateRequest(새로운_닉네임, 새로운_이미지);
 
         // when
-        memberService.updateMember(savedMember, updateRequest);
+        memberService.updateMember(savedMember.getId(), updateRequest);
 
         // then
         Member foundMember = memberService.findById(savedMember.getId());
@@ -150,11 +152,11 @@ class MemberServiceTest {
         String 새로운_닉네임 = "브라운2세";
         String 새로운_이미지 = "superPowerImageUrl";
 
-        Member member = new Member("gracefulBrown", 기존_닉네임, Role.CREW, 1L, 기존_이미지);
+        Member member = new Member(Long.MIN_VALUE, "gracefulBrown", 기존_닉네임, Role.CREW, 1L, 기존_이미지);
         MemberUpdateRequest updateRequest = new MemberUpdateRequest(새로운_닉네임, 새로운_이미지);
 
         // when, then
-        assertThatThrownBy(() -> memberService.updateMember(member, updateRequest))
+        assertThatThrownBy(() -> memberService.updateMember(member.getId(), updateRequest))
             .isExactlyInstanceOf(MemberNotFoundException.class);
     }
 

--- a/backend/src/test/java/wooteco/prolog/posttag/application/StudylogTagServiceTest.java
+++ b/backend/src/test/java/wooteco/prolog/posttag/application/StudylogTagServiceTest.java
@@ -16,6 +16,8 @@ import org.springframework.test.context.TestConstructor;
 import org.springframework.test.context.TestConstructor.AutowireMode;
 import org.springframework.transaction.annotation.Transactional;
 import wooteco.prolog.login.application.dto.GithubProfileResponse;
+import wooteco.prolog.login.ui.LoginMember;
+import wooteco.prolog.login.ui.LoginMember.Authority;
 import wooteco.prolog.member.application.MemberService;
 import wooteco.prolog.member.domain.Member;
 import wooteco.prolog.studylog.application.LevelService;
@@ -91,7 +93,7 @@ class StudylogTagServiceTest {
                 .map(it -> new StudylogRequest("이름", "별명", 1L, it))
                 .collect(toList());
 
-        return studylogService.insertStudylogs(member, posts);
+        return studylogService.insertStudylogs(member.getId(), posts);
     }
 
     private List<TagRequest> createTagRequests(String... tags) {

--- a/backend/src/test/java/wooteco/prolog/studylog/studylog/application/StudylogServiceTest.java
+++ b/backend/src/test/java/wooteco/prolog/studylog/studylog/application/StudylogServiceTest.java
@@ -25,6 +25,8 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.transaction.annotation.Transactional;
 import wooteco.prolog.login.application.dto.GithubProfileResponse;
+import wooteco.prolog.login.ui.LoginMember;
+import wooteco.prolog.login.ui.LoginMember.Authority;
 import wooteco.prolog.member.application.MemberService;
 import wooteco.prolog.member.application.dto.MemberResponse;
 import wooteco.prolog.member.domain.Member;
@@ -303,7 +305,7 @@ class StudylogServiceTest {
                                                                     toTagRequests(tags));
 
         //when
-        studylogService.updateStudylog(member1, targetStudylog.getId(), updateStudylogRequest);
+        studylogService.updateStudylog(member1.getId(), targetStudylog.getId(), updateStudylogRequest);
 
         //then
         StudylogResponse expectedResult = studylogService.findById(targetStudylog.getId());
@@ -332,7 +334,7 @@ class StudylogServiceTest {
                                                                     2L,
                                                                     toTagRequests(tags));
 
-        studylogService.updateStudylog(member1, id, updateStudylogRequest);
+        studylogService.updateStudylog(member1.getId(), id, updateStudylogRequest);
 
         // when
         StudylogDocument studylogDocument = studylogDocumentService.findById(id);
@@ -359,7 +361,7 @@ class StudylogServiceTest {
             .collect(toList());
 
         Long removedId = studylogIds.remove(0);
-        studylogService.deleteStudylog(member1, removedId);
+        studylogService.deleteStudylog(member1.getId(), removedId);
 
         //then
         StudylogsResponse studylogsResponse = studylogService
@@ -396,7 +398,7 @@ class StudylogServiceTest {
         List<StudylogResponse> studylogResponses = insertStudylogs(member1, studylog1);
         Long id = studylogResponses.get(0).getId();
 
-        studylogService.deleteStudylog(member1, id);
+        studylogService.deleteStudylog(member1.getId(), id);
 
         // when - then
         assertThatThrownBy(() -> studylogDocumentService.findById(id))
@@ -415,7 +417,7 @@ class StudylogServiceTest {
             )
             .collect(toList());
 
-        return studylogService.insertStudylogs(member, studylogRequests);
+        return studylogService.insertStudylogs(member.getId(), studylogRequests);
     }
 
     private List<StudylogResponse> insertStudylogs(Member member, Studylog... studylogs) {
@@ -432,5 +434,9 @@ class StudylogServiceTest {
         return tags.stream()
             .map(tag -> new TagRequest(tag.getName()))
             .collect(toList());
+    }
+
+    private LoginMember toLoginMember(Member member) {
+        return new LoginMember(member.getId(), Authority.MEMBER);
     }
 }

--- a/backend/src/test/java/wooteco/prolog/studylog/studylog/util/StudylogUtilCRUD.java
+++ b/backend/src/test/java/wooteco/prolog/studylog/studylog/util/StudylogUtilCRUD.java
@@ -6,6 +6,9 @@ import java.util.List;
 import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import wooteco.prolog.login.ui.LoginMember;
+import wooteco.prolog.login.ui.LoginMember.Authority;
+import wooteco.prolog.member.domain.Member;
 import wooteco.prolog.member.util.MemberFixture;
 import wooteco.prolog.member.util.MemberUtilCRUD;
 import wooteco.prolog.studylog.application.StudylogService;
@@ -21,7 +24,8 @@ public class StudylogUtilCRUD {
     private MemberUtilCRUD memberUtilCRUD;
 
     public void 등록(StudylogFixture studylogFixture, MemberFixture member) {
-        studylogService.insertStudylogs(memberUtilCRUD.등록(member), Collections.singletonList(
+        final Member insertMember = memberUtilCRUD.등록(member);
+        studylogService.insertStudylogs(insertMember.getId(), Collections.singletonList(
             studylogFixture.asRequest()));
     }
 
@@ -30,7 +34,7 @@ public class StudylogUtilCRUD {
                 .map(TagRequest::new)
                 .collect(Collectors.toList());
 
-        studylogService.insertStudylogs(memberUtilCRUD.등록(memberFixture), Collections.singletonList(new StudylogRequest(title, content, missionId, tagRequests)));
+        studylogService.insertStudylogs(memberUtilCRUD.등록(memberFixture).getId(), Collections.singletonList(new StudylogRequest(title, content, missionId, tagRequests)));
     }
 
     public void 등록(StudylogFixture studylogFixture, MemberFixture memberFixture, String ... tagNames) {
@@ -38,7 +42,7 @@ public class StudylogUtilCRUD {
                 .map(TagRequest::new)
                 .collect(Collectors.toList());
 
-        studylogService.insertStudylogs(memberUtilCRUD.등록(memberFixture), Collections.singletonList(
+        studylogService.insertStudylogs(memberUtilCRUD.등록(memberFixture).getId(), Collections.singletonList(
             studylogFixture.asRequestWithTags(tagRequests)));
     }
 }

--- a/backend/src/test/java/wooteco/prolog/studylog/studylogtag/application/StudylogTagServiceTest.java
+++ b/backend/src/test/java/wooteco/prolog/studylog/studylogtag/application/StudylogTagServiceTest.java
@@ -11,6 +11,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
 import wooteco.prolog.login.application.dto.GithubProfileResponse;
+import wooteco.prolog.login.ui.LoginMember;
+import wooteco.prolog.login.ui.LoginMember.Authority;
 import wooteco.prolog.member.application.MemberService;
 import wooteco.prolog.member.domain.Member;
 import wooteco.prolog.studylog.application.LevelService;
@@ -82,7 +84,7 @@ class StudylogTagServiceTest {
             .map(it -> new StudylogRequest("이름", "별명", 1L, it))
             .collect(toList());
 
-        return studylogService.insertStudylogs(member, studylogs);
+        return studylogService.insertStudylogs(member.getId(), studylogs);
     }
 
     private List<TagRequest> createTagRequests(String... tags) {


### PR DESCRIPTION
변경 전, ArgumentResolver 에서 직접적으로 MemberService를 호출해 Member 도메인을 완성하는 과정이었습니다!
변경 후, ArgumentResolver는 Token 값만 확인해 유효한 토큰이 존재한다면 Member 권한을 갖고 유효한 토큰이 아니거나 존재하지 않다면 Anonymous 권한을 갖게끔 설계했습니다. 
여기서 사용되는 DTO 명은 `LoginMember` 로 만들었습니다!

그리고 AOP를 이용해 `@OnlyMember`가 붙어있는 api 는 무조건 Member 권한이어야만 호출될 수 있게끔 만들었습니다!
(#414 이슈에서 분기 처리가 필요한 부분도 필요하기에 `@OnlyMember` 를 사용하지 않는다면 분기 처리로 해결할 수 있습니다!)