### PR TITLE
[ #258] /member/me 를 [GET, PUT] /member/{username} 으로 변경한다.

### DIFF
--- a/backend/src/acceptanceTest/java/wooteco/prolog/AcceptanceContext.java
+++ b/backend/src/acceptanceTest/java/wooteco/prolog/AcceptanceContext.java
@@ -7,6 +7,9 @@ import io.restassured.specification.RequestSpecification;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
 
+import java.util.HashMap;
+import java.util.Map;
+
 @Component
 @Scope(scopeName = "cucumber-glue")
 public class AcceptanceContext {
@@ -14,6 +17,7 @@ public class AcceptanceContext {
     public RequestSpecification request;
     public Response response;
     public String accessToken;
+    public Map<String, Object> storage;
 
     public AcceptanceContext() {
         reset();
@@ -23,6 +27,7 @@ public class AcceptanceContext {
         request = null;
         response = null;
         accessToken = "";
+        storage = new HashMap<>();
     }
 
     public void invokeHttpGet(String path, Object... pathParams) {

--- a/backend/src/acceptanceTest/java/wooteco/prolog/steps/LoginStepDefinitions.java
+++ b/backend/src/acceptanceTest/java/wooteco/prolog/steps/LoginStepDefinitions.java
@@ -20,6 +20,8 @@ public class LoginStepDefinitions extends AcceptanceSteps {
         context.invokeHttpPost("/login/token", data);
         TokenResponse tokenResponse = context.response.as(TokenResponse.class);
         context.accessToken = tokenResponse.getAccessToken();
+
+        context.storage.put("username", GithubResponses.findByName(member).getLogin());
     }
 
     @When("{string}(이)(가) 로그인을 하면")

--- a/backend/src/acceptanceTest/java/wooteco/prolog/steps/MemberStepDefinitions.java
+++ b/backend/src/acceptanceTest/java/wooteco/prolog/steps/MemberStepDefinitions.java
@@ -19,7 +19,8 @@ public class MemberStepDefinitions extends AcceptanceSteps {
 
     @When("자신의 멤버 정보를 조회하면")
     public void 자신의멤버정보를조회하면() {
-        context.invokeHttpGetWithToken("/members/me");
+        String username = (String) context.storage.get("username");
+        context.invokeHttpGetWithToken("/members/" + username);
     }
 
     @Then("멤버 정보가 조회된다")
@@ -34,8 +35,8 @@ public class MemberStepDefinitions extends AcceptanceSteps {
         MemberUpdateRequest updateRequest = new MemberUpdateRequest(
             updatedNickname, ""
         );
-
-        context.invokeHttpPutWithToken("/members/me", updateRequest);
+        String username = (String) context.storage.get("username");
+        context.invokeHttpPutWithToken("/members/" + username, updateRequest);
     }
 
     @Then("{string}의 닉네임이 {string}(로)(으로) 수정")

--- a/backend/src/documentation/java/wooteco/prolog/docu/LoginDocumentation.java
+++ b/backend/src/documentation/java/wooteco/prolog/docu/LoginDocumentation.java
@@ -22,15 +22,6 @@ public class LoginDocumentation extends Documentation {
     }
 
     @Test
-    void 자신의_사용자_정보를_조회한다() {
-        given("members/me")
-            .header("Authorization", "Bearer " + 로그인_사용자.getAccessToken())
-            .when().get("/members/me")
-            .then().log().all()
-            .extract();
-    }
-
-    @Test
     void 사용자_정보를_조회한다() {
         given("members/read")
             .header("Authorization", "Bearer " + 로그인_사용자.getAccessToken())

--- a/backend/src/documentation/java/wooteco/prolog/docu/LoginDocumentation.java
+++ b/backend/src/documentation/java/wooteco/prolog/docu/LoginDocumentation.java
@@ -20,13 +20,4 @@ public class LoginDocumentation extends Documentation {
             .then().log().all()
             .extract().as(TokenResponse.class);
     }
-
-    @Test
-    void 사용자_정보를_조회한다() {
-        given("members/read")
-            .header("Authorization", "Bearer " + 로그인_사용자.getAccessToken())
-            .when().get("/members/{username}", GithubResponses.소롱.getLogin())
-            .then().log().all()
-            .extract();
-    }
 }

--- a/backend/src/documentation/java/wooteco/prolog/docu/MemberDocumentation.java
+++ b/backend/src/documentation/java/wooteco/prolog/docu/MemberDocumentation.java
@@ -18,7 +18,7 @@ public class MemberDocumentation extends Documentation {
             .header("Authorization", "Bearer " + 로그인_사용자.getAccessToken())
             .body(memberUpdateRequest)
             .contentType(MediaType.APPLICATION_JSON_VALUE)
-            .when().put("/members/" + GithubResponses.소롱.getLogin())
+            .when().put("/members/{username}", GithubResponses.소롱.getLogin())
             .then().log().all()
             .extract();
     }

--- a/backend/src/documentation/java/wooteco/prolog/docu/MemberDocumentation.java
+++ b/backend/src/documentation/java/wooteco/prolog/docu/MemberDocumentation.java
@@ -9,15 +9,6 @@ import wooteco.prolog.member.application.dto.MemberUpdateRequest;
 public class MemberDocumentation extends Documentation {
 
     @Test
-    void 자신의_사용자_정보를_조회한다() {
-        given("members/me")
-            .header("Authorization", "Bearer " + 로그인_사용자.getAccessToken())
-            .when().get("/members/me")
-            .then().log().all()
-            .extract();
-    }
-
-    @Test
     void 자신의_사용자_정보를_수정한다() {
         MemberUpdateRequest memberUpdateRequest = new MemberUpdateRequest(
             "다른이름",
@@ -27,7 +18,7 @@ public class MemberDocumentation extends Documentation {
             .header("Authorization", "Bearer " + 로그인_사용자.getAccessToken())
             .body(memberUpdateRequest)
             .contentType(MediaType.APPLICATION_JSON_VALUE)
-            .when().put("/members/me")
+            .when().put("/members/" + GithubResponses.소롱.getLogin())
             .then().log().all()
             .extract();
     }

--- a/backend/src/main/java/wooteco/prolog/member/ui/MemberController.java
+++ b/backend/src/main/java/wooteco/prolog/member/ui/MemberController.java
@@ -23,6 +23,7 @@ public class MemberController {
 
     private MemberService memberService;
 
+    @Deprecated
     @GetMapping(value = "/me", produces = MediaType.APPLICATION_JSON_VALUE)
     @MemberOnly
     public ResponseEntity<MemberResponse> findMemberInfoOfMine(@AuthMemberPrincipal LoginMember member) {
@@ -34,13 +35,24 @@ public class MemberController {
         return ResponseEntity.ok().body(MemberResponse.of(memberService.findByUsername(username)));
     }
 
+    @PutMapping("/{username}")
+    public ResponseEntity<Void> updateStudylog(
+        @AuthMemberPrincipal LoginMember member,
+        @PathVariable String username,
+        @RequestBody MemberUpdateRequest updateRequest
+    ) {
+        memberService.updateMember(member, username, updateRequest);
+        return ResponseEntity.ok().build();
+    }
+
+    @Deprecated
     @PutMapping("/me")
     @MemberOnly
-    public ResponseEntity<Void> updateStudylog(
+    public ResponseEntity<Void> updateStudylog_deprecated(
         @AuthMemberPrincipal LoginMember member,
         @RequestBody MemberUpdateRequest updateRequest
     ) {
-        memberService.updateMember(member.getId(), updateRequest);
+        memberService.updateMember_deprecated(member.getId(), updateRequest);
         return ResponseEntity.ok().build();
     }
 }

--- a/backend/src/main/java/wooteco/prolog/member/ui/MemberController.java
+++ b/backend/src/main/java/wooteco/prolog/member/ui/MemberController.java
@@ -36,7 +36,7 @@ public class MemberController {
     }
 
     @PutMapping("/{username}")
-    public ResponseEntity<Void> updateStudylog(
+    public ResponseEntity<Void> updateMember(
         @AuthMemberPrincipal LoginMember member,
         @PathVariable String username,
         @RequestBody MemberUpdateRequest updateRequest
@@ -48,7 +48,7 @@ public class MemberController {
     @Deprecated
     @PutMapping("/me")
     @MemberOnly
-    public ResponseEntity<Void> updateStudylog_deprecated(
+    public ResponseEntity<Void> updateMember_deprecated(
         @AuthMemberPrincipal LoginMember member,
         @RequestBody MemberUpdateRequest updateRequest
     ) {

--- a/backend/src/test/java/wooteco/prolog/member/application/MemberServiceTest.java
+++ b/backend/src/test/java/wooteco/prolog/member/application/MemberServiceTest.java
@@ -32,9 +32,9 @@ class MemberServiceTest {
     void findOrCreateMemberTest() {
         // given
         GithubProfileResponse brownResponse = new GithubProfileResponse("브라운", "gracefulBrown", "1",
-                                                                        "imageUrl1");
+                "imageUrl1");
         GithubProfileResponse jasonResponse = new GithubProfileResponse("제이슨", "pjs", "2",
-                                                                        "imageUrl2");
+                "imageUrl2");
 
         Member를_생성한다(brownResponse.toMember());
 
@@ -53,14 +53,14 @@ class MemberServiceTest {
     void findByIdTest() {
         // given
         Member savedMember = Member를_생성한다(
-            new Member("gracefulBrown", "브라운", Role.CREW, 1L, "imageUrl"));
+                new Member("gracefulBrown", "브라운", Role.CREW, 1L, "imageUrl"));
 
         // when
         Member foundMember = memberService.findById(savedMember.getId());
 
         // then
         assertThat(foundMember).usingRecursiveComparison()
-            .isEqualTo(savedMember);
+                .isEqualTo(savedMember);
     }
 
     @DisplayName("ID를 통해서 Member 조회 실패시 지정된 예외가 발생한다.")
@@ -68,7 +68,7 @@ class MemberServiceTest {
     void findByIdExceptionTest() {
         // when, then
         assertThatThrownBy(() -> memberService.findById(999L))
-            .isExactlyInstanceOf(MemberNotFoundException.class);
+                .isExactlyInstanceOf(MemberNotFoundException.class);
     }
 
     @DisplayName("Username을 통해서 Member를 조회한다.")
@@ -77,14 +77,14 @@ class MemberServiceTest {
     void findByUsernameTest() {
         // given
         Member savedMember = Member를_생성한다(
-            new Member("gracefulBrown", "브라운", Role.CREW, 1L, "imageUrl"));
+                new Member("gracefulBrown", "브라운", Role.CREW, 1L, "imageUrl"));
 
         // when
         Member foundMember = memberService.findByUsername(savedMember.getUsername());
 
         // then
         assertThat(foundMember).usingRecursiveComparison()
-            .isEqualTo(savedMember);
+                .isEqualTo(savedMember);
     }
 
     @DisplayName("Username를 통해서 Member 조회 실패시 지정된 예외가 발생한다.")
@@ -92,7 +92,7 @@ class MemberServiceTest {
     void findByUsernameExceptionTest() {
         // when, then
         assertThatThrownBy(() -> memberService.findByUsername("이 세상에 존재할 수 없는 이름"))
-            .isExactlyInstanceOf(MemberNotFoundException.class);
+                .isExactlyInstanceOf(MemberNotFoundException.class);
     }
 
     @DisplayName("Username을 통해서 MemberResponse를 조회한다.")
@@ -100,16 +100,16 @@ class MemberServiceTest {
     void findMemberResponseByUsernameTest() {
         // given
         Member savedMember = Member를_생성한다(
-            new Member("gracefulBrown", "브라운", Role.CREW, 1L, "imageUrl"));
+                new Member("gracefulBrown", "브라운", Role.CREW, 1L, "imageUrl"));
         MemberResponse expectMemberResponse = MemberResponse.of(savedMember);
 
         // when
         MemberResponse foundMemberResponse = memberService
-            .findMemberResponseByUsername(savedMember.getUsername());
+                .findMemberResponseByUsername(savedMember.getUsername());
 
         // then
         assertThat(foundMemberResponse).usingRecursiveComparison()
-            .isEqualTo(expectMemberResponse);
+                .isEqualTo(expectMemberResponse);
     }
 
     @DisplayName("Username를 통해서 MemberResponse 조회 실패시 지정된 예외가 발생한다.")
@@ -117,7 +117,7 @@ class MemberServiceTest {
     void findMemberResponseByUsernameExceptionTest() {
         // when, then
         assertThatThrownBy(() -> memberService.findMemberResponseByUsername("이 세상에 존재할 수 없는 이름"))
-            .isExactlyInstanceOf(MemberNotFoundException.class);
+                .isExactlyInstanceOf(MemberNotFoundException.class);
     }
 
     @DisplayName("Member 정보를 업데이트 한다.")
@@ -130,11 +130,15 @@ class MemberServiceTest {
         String 새로운_이미지 = "superPowerImageUrl";
 
         Member savedMember = Member를_생성한다(
-            new Member("gracefulBrown", 기존_닉네임, Role.CREW, 1L, 기존_이미지));
+                new Member("gracefulBrown", 기존_닉네임, Role.CREW, 1L, 기존_이미지));
         MemberUpdateRequest updateRequest = new MemberUpdateRequest(새로운_닉네임, 새로운_이미지);
 
         // when
-        memberService.updateMember(savedMember.getId(), updateRequest);
+        memberService.updateMember(
+                new LoginMember(savedMember.getId(), Authority.MEMBER),
+                savedMember.getUsername(),
+                updateRequest
+        );
 
         // then
         Member foundMember = memberService.findById(savedMember.getId());
@@ -156,8 +160,11 @@ class MemberServiceTest {
         MemberUpdateRequest updateRequest = new MemberUpdateRequest(새로운_닉네임, 새로운_이미지);
 
         // when, then
-        assertThatThrownBy(() -> memberService.updateMember(member.getId(), updateRequest))
-            .isExactlyInstanceOf(MemberNotFoundException.class);
+        assertThatThrownBy(() -> memberService.updateMember(
+                new LoginMember(member.getId(), Authority.MEMBER),
+                member.getUsername(),
+                updateRequest
+        )).isExactlyInstanceOf(MemberNotFoundException.class);
     }
 
     private Member Member를_생성한다(Member member) {


### PR DESCRIPTION
기존의 me로 동작하던 API들이 정상적으로 동작할 수 있도록 남겨두고 Deprecate시켜놨습니다. 프론트측에서 수정이 완료시 Deprecate된 메서드를 제거할 예정입니다.

추가적으로 Acceptacne context쪽에 storage Map을 추가했습니다. 각 step마다 데이터 공유가 불편해서 추가하였고 이를 통해서 인수테스트 작성에 조금 더 편해질것으로 예상합니다.

resolve #258 