### PR TITLE
feat: 쉽게 api 성능을 확인할 수 있는 로그 추가

### DIFF
--- a/backend/src/main/java/wooteco/prolog/common/performance/PerformanceLogger.java
+++ b/backend/src/main/java/wooteco/prolog/common/performance/PerformanceLogger.java
@@ -1,0 +1,64 @@
+package wooteco.prolog.common.performance;
+
+import java.lang.reflect.Proxy;
+import java.sql.Connection;
+import javax.servlet.http.HttpServletRequest;
+import javax.sql.DataSource;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.After;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+@Component
+@Profile("!prod")
+@Aspect
+public class PerformanceLogger {
+
+    private ThreadLocal<PerformanceLoggingForm> logForm;
+
+    @Before("@within(org.springframework.transaction.annotation.Transactional) || @annotation(org.springframework.transaction.annotation.Transactional)")
+    public void beforeTransaction() {
+        getLoggingForm().setTransactionStartTime(System.currentTimeMillis());
+        try {
+            HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getRequest();
+            getLoggingForm().setTargetApi(request.getRequestURI());
+        } catch (IllegalStateException e) {
+            getLoggingForm().setTargetApi("dataLoader");
+        }
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                getLoggingForm().setTransactionEndTime(System.currentTimeMillis());
+                getLoggingForm().printLog();
+                getLoggingForm().resetQueryCount();
+            }
+        });
+    }
+
+    @Around("execution(* javax.sql.DataSource.getConnection())")
+    public Object datasource(ProceedingJoinPoint proceedingJoinPoint) throws Throwable {
+        final Object proceed = proceedingJoinPoint.proceed();
+        return Proxy.newProxyInstance(
+            proceed.getClass().getClassLoader(),
+            proceed.getClass().getInterfaces(),
+            new ProxyConnectionHandler(proceed, getLoggingForm()));
+    }
+
+    private PerformanceLoggingForm getLoggingForm() {
+        if(logForm == null) {
+            logForm = new ThreadLocal<>();
+        }
+
+        if(logForm.get() == null) {
+            logForm.set(new PerformanceLoggingForm());
+        }
+        return logForm.get();
+    }
+}

--- a/backend/src/main/java/wooteco/prolog/common/performance/PerformanceLoggingForm.java
+++ b/backend/src/main/java/wooteco/prolog/common/performance/PerformanceLoggingForm.java
@@ -1,0 +1,30 @@
+package wooteco.prolog.common.performance;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+
+@Getter
+@Setter
+@Slf4j
+public class PerformanceLoggingForm {
+
+    private static final String LOG_FORM = "요청 api : [{}]  트랜잭션 시간 : [{}ms]  쿼리 개수 : [{}개]";
+
+    private Long transactionStartTime;
+    private Long transactionEndTime;
+    private Long queryCounts = 0L;
+    private String targetApi;
+
+    public void queryCountUp() {
+        queryCounts++;
+    }
+
+    public void printLog() {
+        log.info(LOG_FORM, targetApi, transactionEndTime - transactionStartTime, queryCounts);
+    }
+
+    public void resetQueryCount() {
+        queryCounts = 0L;
+    }
+}

--- a/backend/src/main/java/wooteco/prolog/common/performance/ProxyConnectionHandler.java
+++ b/backend/src/main/java/wooteco/prolog/common/performance/ProxyConnectionHandler.java
@@ -1,0 +1,28 @@
+package wooteco.prolog.common.performance;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+
+public class ProxyConnectionHandler implements InvocationHandler {
+
+    private final Object connection;
+    private final PerformanceLoggingForm loggingForm;
+
+    public ProxyConnectionHandler(Object connection, PerformanceLoggingForm loggingForm) {
+        this.connection = connection;
+        this.loggingForm = loggingForm;
+    }
+
+    @Override
+    public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+        final Object returnValue = method.invoke(connection, args);
+        if (method.getName().equals("prepareStatement")) {
+            return Proxy.newProxyInstance(
+                returnValue.getClass().getClassLoader(),
+                returnValue.getClass().getInterfaces(),
+                new ProxyPreparedStatementHandler(returnValue, loggingForm));
+        }
+        return returnValue;
+    }
+}

--- a/backend/src/main/java/wooteco/prolog/common/performance/ProxyPreparedStatementHandler.java
+++ b/backend/src/main/java/wooteco/prolog/common/performance/ProxyPreparedStatementHandler.java
@@ -1,0 +1,24 @@
+package wooteco.prolog.common.performance;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+
+public class ProxyPreparedStatementHandler implements InvocationHandler {
+
+    private final Object preparedStatement;
+    private final PerformanceLoggingForm loggingForm;
+
+    public ProxyPreparedStatementHandler(Object preparedStatement,
+                                         PerformanceLoggingForm loggingForm) {
+        this.preparedStatement = preparedStatement;
+        this.loggingForm = loggingForm;
+    }
+
+    @Override
+    public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+        if(method.getName().equals("executeQuery")) {
+            loggingForm.queryCountUp();
+        }
+        return method.invoke(preparedStatement, args);
+    }
+}


### PR DESCRIPTION
### resolved  #447

성능을 측정할 수 있는 로그를 만들어봤습니다!
동적으로 프록시가 생성되다 보니 성능은 좋지 않을 것 같아서 prod 환경에서는 제외시켰습니다!
트랜잭션 관련해 이것저것 해보다가 이런 기능도 있으면 좋겠다 생각해서 갑작스레 만들게 되었습니다!
별로면 언제든 이야기 해주세요!! =]  학습 겸 만들어 본 것이라 구현해 봤다에 만족합니다!!

로그는 api, 트랜잭션 시간, 쿼리 개수가 포함되어 있습니다.
형식은 아래와 같습니다!

```
2021-10-02 22:34:09.048  INFO 7028 --- [nio-5000-exec-4] w.p.c.p.PerformanceLoggingForm           : 요청 api : [/posts]  트랜잭션 시간 : [25ms]  쿼리 개수 : [9개]

2021-10-02 22:29:04.882  INFO 7028 --- [nio-5000-exec-1] w.p.c.p.PerformanceLoggingForm           : 요청 api : [/members/gracefulBrown/posts]  트랜잭션 시간 : [50ms]  쿼리 개수 : [10개]
```