### PR TITLE
fix: 리포트 제목 문자열 양 끝 공백 제거

### DIFF
--- a/frontend/src/pages/ProfilePageNewReport/index.js
+++ b/frontend/src/pages/ProfilePageNewReport/index.js
@@ -63,9 +63,12 @@ const ProfilePageNewReport = () => {
   const onSubmitReport = (event) => {
     event.preventDefault();
 
+    const currTitle = title.trim();
+
     const data = {
       id: null,
-      title: title !== '' ? title : `${new Date().toLocaleDateString()} ${nickname}의 리포트`,
+      title:
+        currTitle !== '' ? currTitle : `${new Date().toLocaleDateString()} ${nickname}의 리포트`,
       description,
       abilityGraph: { abilities: [] },
       studylogs: studyLogs.map((item) => ({ id: item.id, abilities: [] })),


### PR DESCRIPTION
### resolved #465 
- 리포트 title에서 양 끝에 공백을 제거하는 `trim()` 메소드 추가