### PR TITLE
feat: 적합하지 않은 JWT 토큰 parsing 시 예외를 catch하는 로직 추가

### DIFF
--- a/backend/src/main/java/wooteco/prolog/login/application/JwtTokenProvider.java
+++ b/backend/src/main/java/wooteco/prolog/login/application/JwtTokenProvider.java
@@ -6,11 +6,14 @@ import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import java.util.Date;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
+import wooteco.prolog.login.excetpion.TokenNotValidException;
 import wooteco.prolog.member.domain.Member;
 
 @Component
+@Slf4j
 public class JwtTokenProvider {
 
     @Value("${security.jwt.token.secret-key}")
@@ -42,6 +45,12 @@ public class JwtTokenProvider {
     }
 
     public String extractSubject(String token) {
-        return Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token).getBody().getSubject();
+        try {
+            return Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token).getBody()
+                .getSubject();
+        } catch (JwtException | IllegalArgumentException e) {
+            log.warn(e.getMessage(), e);
+            throw new TokenNotValidException();
+        }
     }
 }

--- a/backend/src/main/java/wooteco/prolog/login/application/JwtTokenProvider.java
+++ b/backend/src/main/java/wooteco/prolog/login/application/JwtTokenProvider.java
@@ -49,7 +49,7 @@ public class JwtTokenProvider {
             return Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token).getBody()
                 .getSubject();
         } catch (JwtException | IllegalArgumentException e) {
-            log.warn(e.getMessage(), e);
+            log.info(e.getMessage(), e);
             throw new TokenNotValidException();
         }
     }

--- a/backend/src/test/java/wooteco/prolog/login/application/JwtTokenProviderTest.java
+++ b/backend/src/test/java/wooteco/prolog/login/application/JwtTokenProviderTest.java
@@ -1,0 +1,46 @@
+package wooteco.prolog.login.application;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import java.util.Date;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import wooteco.prolog.login.excetpion.TokenNotValidException;
+import wooteco.prolog.member.domain.Role;
+
+@ActiveProfiles("test")
+@SpringBootTest
+class JwtTokenProviderTest {
+    @Value("${security.jwt.token.secret-key}")
+    private String secretKey;
+
+    @DisplayName("유효하지 않은 JWT 토큰이 입력됐을 때 TokenNotValidException이 발생하는지 확인 ")
+    @Test
+    void jwtTokenProviderValidationCheck() {
+        //given
+        JwtTokenProvider jwtTokenProvider = new JwtTokenProvider();
+        Date now = new Date();
+        Date expiredDate = new Date(now.getTime() - 100);
+
+        String expiredToken = Jwts.builder()
+            .setSubject("1")
+            .setIssuedAt(now)
+            .setExpiration(expiredDate)
+            .claim("role", Role.CREW)
+            .signWith(SignatureAlgorithm.HS256, secretKey)
+            .compact();
+
+        String malformedToken = "단단히잘못된토큰";
+        //when
+        //then
+        assertThatThrownBy(() -> jwtTokenProvider.extractSubject(expiredToken))
+            .isInstanceOf(TokenNotValidException.class);
+        assertThatThrownBy(() -> jwtTokenProvider.extractSubject(malformedToken))
+            .isInstanceOf(TokenNotValidException.class);
+    }
+}


### PR DESCRIPTION
resolve #477 

존맛탱 토큰이 만료되거나 기타 유효하지 않은 토큰일 시, Runtime Exception이 아닌 적합한 예외코드를 반환하도록 수정하였습니다. 정확한 예외 발생지점을 확인할 수 없어 배포 후 확인이 필요합니다.