### PR TITLE
슬랙 로거의 감지 레벨을 error로 향상한다.

### DIFF
--- a/backend/src/main/resources/logback/slack-logger.xml
+++ b/backend/src/main/resources/logback/slack-logger.xml
@@ -11,7 +11,7 @@
   <appender name="prod-async-slack-logger" class="ch.qos.logback.classic.AsyncAppender">
     <appender-ref ref="prod-slack-logger" />
     <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-      <level>WARN</level>
+      <level>ERROR</level>
     </filter>
   </appender>
 
@@ -26,7 +26,7 @@
   <appender name="dev-async-slack-logger" class="ch.qos.logback.classic.AsyncAppender">
     <appender-ref ref="dev-slack-logger" />
     <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-      <level>WARN</level>
+      <level>ERROR</level>
     </filter>
   </appender>
 </included>


### PR DESCRIPTION
ERROR로 올려서 jwt token에러와 같은 자잘한 에러는 알람이 오지 않도록 한다.

resolve #496 