### PR TITLE
fix: 학습로그 수정시 글이 불러와 지지 않는 이슈 해결 (#498)

### DIFF
--- a/frontend/src/pages/EditPostPage/index.js
+++ b/frontend/src/pages/EditPostPage/index.js
@@ -15,7 +15,7 @@ const EditPostPage = () => {
 
   const { id: postId } = useParams();
   const { editData: editPost } = usePost({});
-  const [post] = useFetch({}, () => requestGetPost(postId));
+  const [post] = useFetch({}, () => requestGetPost('', postId));
 
   const [selectedMission, setSelectedMission] = useState('');
   const cardRefs = useRef([]);


### PR DESCRIPTION
- editPage에서 기존 데이터 요청 시 파라미터 오류 있었음.
- getPost 시 accessToken 여부에 대해서 논의 필요할 듯.