### PR TITLE
[검색] elasticsearch index mapping을 코드에 포함한다.

### DIFF
--- a/search/mapping-index-and-sync/HELP.md
+++ b/search/mapping-index-and-sync/HELP.md
@@ -1,0 +1,3 @@
+## HOW TO RUN
+chmod 744 mapping-index-and-sync.sh
+./mapping-index-and-sync.sh

--- a/search/mapping-index-and-sync/mapping-index-and-sync.sh
+++ b/search/mapping-index-and-sync/mapping-index-and-sync.sh
@@ -1,4 +1,15 @@
-#!/bin/sh
+#!/bin/bash
+
+DEV_API="https://dev-api.prolog.techcourse.co.kr"
+PROD_API="https://api.prolog.techcourse.co.kr"
+USE_API=""
+
+if [ $USER == "ELASTIC-STACK-DEV" ];then
+	USE_API=${DEV_API}
+else
+	USE_API=${PROD_API}
+fi
+
 curl -X PUT "localhost:9200/studylog-document?pretty" -H 'Content-Type: application/json' -d'
 {
   "settings":{
@@ -31,4 +42,4 @@ curl -X PUT "localhost:9200/studylog-document?pretty" -H 'Content-Type: applicat
 }
 '
 
-curl -v https://dev-api.prolog.techcourse.co.kr/sync
+curl -v ${USE_API}/sync

--- a/search/mapping-index-and-sync/mapping-index-and-sync.sh
+++ b/search/mapping-index-and-sync/mapping-index-and-sync.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+curl -X PUT "localhost:9200/studylog-document?pretty" -H 'Content-Type: application/json' -d'
+{
+  "settings":{
+      "index":{
+        "analysis":{
+          "tokenizer":{
+            "nori_tokenizer_mixed_dict":{
+              "type":"nori_tokenizer",
+              "decompound_mode":"mixed"
+            }
+          },
+          "analyzer": {
+            "korean":{
+              "type":"custom",
+              "tokenizer":"nori_tokenizer_mixed_dict",
+              "filter":[
+                "nori_readingform","lowercase",
+                "nori_part_of_speech_basic"]
+              }
+            },
+            "filter":{
+              "nori_part_of_speech_basic":{
+                "type":"nori_part_of_speech",
+                "stoptags":["E","IC","J","MAG","MAJ","MM","SP","SSC","SSO","SC","SE","XPN","XSA","XSN","XSV","UNA","NA","VSV"]
+          }
+        }
+      }
+    }
+  }
+}
+'
+
+curl -v https://dev-api.prolog.techcourse.co.kr/sync


### PR DESCRIPTION
close #521 

엘라스틱 서치 index mapping에 사용되는 내용이 closed issue에만 작성되어있어 레포지토리에 포함했습니다.
특히, index mapping 후에는 RDB와의 sync 작업이 필요한데 둘 모두를 동시에 실행할 수 있도록 하기 위해 쉘 스크립트의 형태로 작성했습니다.
실행 방법은 HELP.md에 명시해두었습니다.
