### PR TITLE
[검색] 검색어로 들어오는 특수문자를 처리한다.

### DIFF
--- a/backend/src/main/java/wooteco/prolog/studylog/application/FakeStudylogDocumentService.java
+++ b/backend/src/main/java/wooteco/prolog/studylog/application/FakeStudylogDocumentService.java
@@ -12,6 +12,7 @@ import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 import wooteco.prolog.common.BaseEntity;
 import wooteco.prolog.studylog.application.dto.StudylogDocumentResponse;
+import wooteco.prolog.studylog.domain.DocumentQueryParser;
 import wooteco.prolog.studylog.domain.Studylog;
 import wooteco.prolog.studylog.domain.repository.StudylogDocumentRepository;
 import wooteco.prolog.studylog.domain.repository.StudylogRepository;
@@ -39,9 +40,9 @@ public class FakeStudylogDocumentService extends AbstractStudylogDocumentService
             .collect(Collectors.toList());
 
         return StudylogDocumentResponse.of(studylogIds,
-                                            studylogs.getTotalElements(),
-                                            studylogs.getTotalPages(),
-                                            studylogs.getNumber());
+                                           studylogs.getTotalElements(),
+                                           studylogs.getTotalPages(),
+                                           studylogs.getNumber());
     }
 
     private Specification<Studylog> makeSpecifications(String keyword, List<Long> tags, List<Long> missions,
@@ -50,16 +51,16 @@ public class FakeStudylogDocumentService extends AbstractStudylogDocumentService
     ) {
         List<String> keywords = new ArrayList<>();
         if (Objects.nonNull(keyword)) {
-            keywords = preprocess(keyword);
+            keywords = DocumentQueryParser.removeSpecialChars(preprocess(keyword));
         }
 
         return StudylogSpecification.likeKeyword("title", keywords)
             .or(StudylogSpecification.likeKeyword("content", keywords))
             .and(StudylogSpecification.findByLevelIn(levels)
-            .and(StudylogSpecification.equalIn("mission", missions))
-            .and(StudylogSpecification.findByTagIn(tags))
-            .and(StudylogSpecification.findByUsernameIn(usernames))
-            .and(StudylogSpecification.findBetweenDate(start, end))
-            .and(StudylogSpecification.distinct(true)));
+                     .and(StudylogSpecification.equalIn("mission", missions))
+                     .and(StudylogSpecification.findByTagIn(tags))
+                     .and(StudylogSpecification.findByUsernameIn(usernames))
+                     .and(StudylogSpecification.findBetweenDate(start, end))
+                     .and(StudylogSpecification.distinct(true)));
     }
 }

--- a/backend/src/main/java/wooteco/prolog/studylog/domain/DocumentQueryParser.java
+++ b/backend/src/main/java/wooteco/prolog/studylog/domain/DocumentQueryParser.java
@@ -1,0 +1,72 @@
+package wooteco.prolog.studylog.domain;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+public class DocumentQueryParser {
+
+    private static final String WILD_CARD = "*";
+    private static final String OR = " OR ";
+    private static final String EMPTY = " ";
+
+    public static List<String> removeSpecialChars(List<String> words) {
+        List<String> results = new ArrayList<>();
+        for (String word : words) {
+            StringBuilder stringBuilder = new StringBuilder();
+            for (int i = 0; i < word.length(); i++) {
+                char c = word.charAt(i);
+                if (c == '\\' || c == '+' || c == '-' || c == '!' || c == '(' || c == ')' || c == ':'
+                    || c == '^' || c == '[' || c == ']' || c == '\"' || c == '{' || c == '}' || c == '~'
+                    || c == '*' || c == '?' || c == '|' || c == '&' || c == '/') {
+                    continue;
+                }
+                stringBuilder.append(c);
+            }
+            String string = stringBuilder.toString();
+            if (!Objects.equals(string, "")) {
+                results.add(string);
+            }
+        }
+
+        if (results.isEmpty()) {
+            results.add(EMPTY);
+        }
+        return results;
+    }
+
+    public static String makeDefaultQueryString(List<String> inputs) {
+        if (Objects.isNull(inputs) || inputs.isEmpty()) {
+            return WILD_CARD;
+        }
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < inputs.size(); i++) {
+            sb.append(inputs.get(i));
+            if (i != inputs.size() - 1) {
+                sb.append(OR);
+            }
+        }
+        return sb.toString();
+    }
+
+    public static String makeKeywordsQueryString(List<String> keywords) {
+        if (Objects.isNull(keywords) || keywords.isEmpty()) {
+            return WILD_CARD;
+        }
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < keywords.size(); i++) {
+            final String value = keywords.get(i);
+
+            if (value.contains(EMPTY)) {
+                sb.append("\"*").append(value).append("*\"");
+            } else {
+                sb.append(WILD_CARD).append(value).append(WILD_CARD);
+            }
+
+            if (i != keywords.size() - 1) {
+                sb.append(OR);
+            }
+        }
+        return sb.toString();
+    }
+}

--- a/backend/src/main/java/wooteco/prolog/studylog/domain/StudylogDocumentQueryBuilder.java
+++ b/backend/src/main/java/wooteco/prolog/studylog/domain/StudylogDocumentQueryBuilder.java
@@ -1,11 +1,14 @@
 package wooteco.prolog.studylog.domain;
 
+import static wooteco.prolog.studylog.domain.DocumentQueryParser.makeDefaultQueryString;
+import static wooteco.prolog.studylog.domain.DocumentQueryParser.makeKeywordsQueryString;
+import static wooteco.prolog.studylog.domain.DocumentQueryParser.removeSpecialChars;
+
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.index.query.QueryStringQueryBuilder;
 import org.elasticsearch.index.query.RangeQueryBuilder;
@@ -15,14 +18,10 @@ import org.springframework.data.elasticsearch.core.query.Query;
 
 public class StudylogDocumentQueryBuilder {
 
-    private static final String WILD_CARD = "*";
-    private static final String OR = " OR ";
-    private static final String EMPTY = " ";
-
     private StudylogDocumentQueryBuilder() {
     }
 
-    public static Query makeQuery(List<String> keywords,
+    public static Query makeQuery(List<String> inputKeywords,
                                   List<Long> tags,
                                   List<Long> missions,
                                   List<Long> levels,
@@ -32,6 +31,7 @@ public class StudylogDocumentQueryBuilder {
                                   Pageable pageable
     ) {
 
+        List<String> keywords = removeSpecialChars(inputKeywords);
         NativeSearchQueryBuilder query = new NativeSearchQueryBuilder();
         makeBoolQuery(query,
                       makeKeywordsQueryString(keywords),
@@ -80,41 +80,6 @@ public class StudylogDocumentQueryBuilder {
         return QueryBuilders
             .queryStringQuery(query)
             .defaultField(field);
-    }
-
-    private static String makeDefaultQueryString(List<String> usernames) {
-        if (Objects.isNull(usernames) || usernames.isEmpty()) {
-            return WILD_CARD;
-        }
-        StringBuilder sb = new StringBuilder();
-        IntStream.range(0, usernames.size()).forEach(i -> {
-            sb.append(usernames.get(i));
-            if (i != usernames.size() - 1) {
-                sb.append(OR);
-            }
-        });
-        return sb.toString();
-    }
-
-    private static String makeKeywordsQueryString(List<String> keywords) {
-        if (Objects.isNull(keywords) || keywords.isEmpty()) {
-            return WILD_CARD;
-        }
-        StringBuilder sb = new StringBuilder();
-        for (int i = 0; i < keywords.size(); i++) {
-            final String value = keywords.get(i);
-
-            if (value.contains(EMPTY)) {
-                sb.append("\"*").append(value).append("*\"");
-            } else {
-                sb.append(WILD_CARD).append(value).append(WILD_CARD);
-            }
-
-            if (i != keywords.size() - 1) {
-                sb.append(OR);
-            }
-        }
-        return sb.toString();
     }
 
     private static void makeFilterQuery(NativeSearchQueryBuilder query, List<Long> tags) {

--- a/backend/src/test/java/wooteco/prolog/studylog/domain/DocumentQueryParserTest.java
+++ b/backend/src/test/java/wooteco/prolog/studylog/domain/DocumentQueryParserTest.java
@@ -1,0 +1,182 @@
+package wooteco.prolog.studylog.domain;
+
+import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static wooteco.prolog.studylog.domain.DocumentQueryParser.removeSpecialChars;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class DocumentQueryParserTest {
+
+    private List<String> escapedChars = Arrays.asList(
+        "?", "!", "/", "\\", "!", "+", "-", "*", "[", "]", "{", "}", "&", "|", "(", ")", ":"
+    );
+
+    @DisplayName("escapedChars가 들어오면 제거한다.")
+    @Test
+    void escapeCharacters() {
+        // given
+        List<String> results = removeSpecialChars(escapedChars);
+
+        // when - then
+        for (String result : results) {
+            assertThat(result).isEqualTo(" ");
+        }
+    }
+
+    @DisplayName("escapedChars가 들어오면 제거한다 - 단어 앞에 붙은 경우")
+    @Test
+    void escapeCharactersFront() {
+        // given
+        List<String> keywords = new ArrayList<>();
+        for (int i = 0; i < escapedChars.size(); i++) {
+            keywords.add(escapedChars.get(i) + "안녕");
+        }
+
+        List<String> results = removeSpecialChars(keywords);
+
+        // when - then
+        for (String result : results) {
+            assertThat(result).isEqualTo("안녕");
+        }
+    }
+
+    @DisplayName("escapedChars가 들어오면 제거한다 - 단어 사이에 붙은 경우")
+    @Test
+    void escapeCharactersMiddle() {
+        // given
+        List<String> keywords = new ArrayList<>();
+        for (int i = 0; i < escapedChars.size(); i++) {
+            keywords.add("1" + escapedChars.get(i) + "1");
+        }
+
+        List<String> results = removeSpecialChars(keywords);
+
+        // when - then
+        for (String result : results) {
+            assertThat(result).isEqualTo("11");
+        }
+    }
+
+    @DisplayName("escapedChars가 들어오면 제거한다 - 단어가 사이에 붙은 경우")
+    @Test
+    void escapeCharactersMiddle2() {
+        // given
+        List<String> keywords = new ArrayList<>();
+        for (int i = 0; i < escapedChars.size(); i++) {
+            keywords.add(escapedChars.get(i) + "1" + escapedChars.get(i));
+        }
+
+        List<String> results = removeSpecialChars(keywords);
+
+        // when - then
+        for (String result : results) {
+            assertThat(result).isEqualTo("1");
+        }
+    }
+
+    @DisplayName("escapedChars가 들어오면 제거한다 - 단어 뒤에 붙은 경우")
+    @Test
+    void escapeCharactersBack() {
+        // given
+        List<String> keywords = new ArrayList<>();
+        for (int i = 0; i < escapedChars.size(); i++) {
+            keywords.add("안녕" + escapedChars.get(i));
+        }
+
+        List<String> results = removeSpecialChars(keywords);
+
+        // when - then
+        for (String result : results) {
+            assertThat(result).isEqualTo("안녕");
+        }
+    }
+
+    @DisplayName("input으로 들어오는 List를 OR로 엮는다. - 비어있는 경우 와일드카드를 리턴한다.")
+    @Test
+    void makeDefaultQueryStringWhenEmpty() {
+        // given
+        String result = DocumentQueryParser.makeDefaultQueryString(emptyList());
+        // when -  then
+        assertThat(result).isEqualTo("*");
+    }
+
+    @DisplayName("input으로 들어오는 List를 OR로 엮는다. - null인 경우 와일드카드를 리턴한다.")
+    @Test
+    void makeDefaultQueryStringWhenNull() {
+        // given
+        String result = DocumentQueryParser.makeDefaultQueryString(null);
+        // when -  then
+        assertThat(result).isEqualTo("*");
+    }
+
+    @DisplayName("input으로 들어오는 List를 OR로 엮는다.")
+    @Test
+    void makeDefaultQueryString() {
+        // given
+        String result = DocumentQueryParser.makeDefaultQueryString(
+            Arrays.asList("joanne", "brown")
+        );
+        // when -  then
+        assertThat(result).isEqualTo("joanne OR brown");
+    }
+
+    @DisplayName("input으로 들어오는 List를 OR로 엮는다. - 하나인 경우 그대로 반환한다.")
+    @Test
+    void makeDefaultQueryStringSingle() {
+        // given
+        String result = DocumentQueryParser.makeDefaultQueryString(
+            Arrays.asList("joanne")
+        );
+        // when -  then
+        assertThat(result).isEqualTo("joanne");
+    }
+
+    @DisplayName("검색 키워드로 들어오는 List에 와일드카드를 포함한다. - 키워드가 비어있는 경우 와일드카드를 리턴한다.")
+    @Test
+    void makeKeywordsQueryStringEmpty() {
+        // given
+        String keyword = DocumentQueryParser.makeKeywordsQueryString(
+            emptyList()
+        );
+        // when - then
+        assertThat(keyword).isEqualTo("*");
+    }
+
+    @DisplayName("검색 키워드로 들어오는 List에 와일드카드를 포함한다. - 키워드가 null인 경우 와일드카드를 리턴한다.")
+    @Test
+    void makeKeywordsQueryStringNull() {
+        // given
+        String keyword = DocumentQueryParser.makeKeywordsQueryString(
+            null
+        );
+        // when - then
+        assertThat(keyword).isEqualTo("*");
+    }
+
+    @DisplayName("검색 키워드로 들어오는 List에 와일드카드를 포함한다.")
+    @Test
+    void makeKeywordsQueryStringSingle() {
+        // given
+        String keyword = DocumentQueryParser.makeKeywordsQueryString(
+            Arrays.asList("java")
+        );
+        // when - then
+        assertThat(keyword).isEqualTo("*java*");
+    }
+
+    @DisplayName("검색 키워드로 들어오는 List에 와일드카드를 포함한다. - 두 개 이상의 경우 와일드카드와 OR로 연결한다.")
+    @Test
+    void makeKeywordsQueryString() {
+        // given
+        String keyword = DocumentQueryParser.makeKeywordsQueryString(
+            Arrays.asList("자바를", "잡아")
+        );
+        // when - then
+        assertThat(keyword).isEqualTo("*자바를* OR *잡아*");
+    }
+}


### PR DESCRIPTION
close #520

elasticsearch에서 제공하는 API를 이용했을 때, 불용어가 있습니다. 
[참고](https://www.elastic.co/guide/en/elasticsearch/reference/1.6/query-dsl-query-string-query.html#_reserved_characters)에 명시된 reversed characters `+ - = && || > < ! ( ) { } [ ] ^ " ~ * ? : \ /`는 검색 시 역슬래쉬로 escape 하지 않는 이상, 올바른 쿼리가 실행되지 않도록 합니다.

예를 들어, "왜지?" 라는 제목의 글이 있을 때,
1. 왜지
2. 지
3. 왜
4. 왜지?
5. 지?
6. ?
1~3을 통해서는 검색이 되지만, 4~6을 이용하면 검색이 정상적으로 되지 않습니다.

그래서 고민해본 것이, [여기](https://esbook.kimjmin.net/06-text-analysis/6.4-character-filter/6.4.2-mapping) 처럼 매핑하는 것입니다. 그래서 다음과 같은 필터를 추가해 테스트해보았습니다. 
```
PUT studylog-document
{
  "settings":{
      "index":{
        "analysis":{
          "tokenizer":{
            "nori_tokenizer_mixed_dict":{
              "type":"nori_tokenizer",
              "decompound_mode":"mixed"
            }
      	},
          "analyzer": {
            "reverse_char_analyzer": {
              "char_filter":[
                "prolog_char_filter"
                ],
                "tokenizer": "whitespace",
                "filter": ["lowercase", "stop","snowball"]
            },
            "korean":{
              "type":"custom",
              "tokenizer":"nori_tokenizer_mixed_dict",
              "filter":[
                "nori_readingform","lowercase",
                "nori_part_of_speech_basic"
                ]
              }
            },
            "char_filter": {
              "prolog_char_filter": {
                "type": "mapping",
                "mappings": [
                  "+ => _plus_",
                  "- => _minus_",
                  "= => _equals_",
                  "& => _ampersands_",
                  "| => _verticalBar_",
                  "> => _greaterThanSign_",
                  "< => _lessThanSign_",
                  "! => _exclamationPoint_",
                  "( => _leftParenthesis_",
                  ") => _rightParenthesis_",
                  "{ => _leftBrace_",
                  "} => _rightBrace_",
                  "[ => _leftBracket_",
                  "] => _rightBracket_",
                  "^ => _circumflex_",
                  "\" => _quotationMark_",
                  "~ => _tilde_",
                  "? => _questionMark_",
                  ": => _colon_",
                  "/ => _slash_"
                  ]
              }
            },
            "filter":{
              "nori_part_of_speech_basic":{
                "type":"nori_part_of_speech",
                "stoptags":["E","IC","J","MAG","MAJ","MM","SP","SSC","SSO","SC","SE","XPN","XSA","XSN","XSV","UNA","NA","VSV"
                ]
              }
            }
          }
        }
  },
  "mappings": {
    "properties": {
      "language": {
        "type": "text",
        "analyzer": "reverse_char_analyzer"
      }
    }
  }
}
```

하지만 프롤로그 검색 로직은 설정한 char_filter를 타고 검색되는 것이 아닌, 직접 QueryBuilder를 통해 만들어진 쿼리가 검색되는 것이므로 java 코드 상에서 매핑 작업을 수행해줘야합니다. 

따라서 reversed characters를 검색 시 제거해주는 방향을 선택했습니다. 그 이유는, 만약 위와 같이 + => _plus_와 같이 매핑한다면 Studylog 삽입, 수정 시 모든 +를 _plus_로 매핑해주는 작업을 애플리케이션단에서 진행해야합니다. 따라서 삽입/수정에는 영향을 미치지 않고, 검색 시에만 제대로 검색이 될 수 있도록 하기 위해 rev_char을 제거해주도록 구성했습니다. 해당 코드는 QueryParserBase 클래스를 참고했습니다.

만약, ? 하나만 검색어로 들어온 경우에는 로직 상 ?가 제거되고 ""로 변환되어 검색 로직을 탔을 때 * 로 반환되기에 모든 결과를 반환하게 됩니다. 따라서 특수문자 하나만 검색어로 들어와 제거 결과가 empty인 경우에는 " "를 검색하도록 하여, 아무것도 검색되지 않도록 막아두었습니다.

제가 임의로 구상해보고 짠 코드인지라, 로직의 변경이 필요하다고 생각되시는 부분은 코멘트로 남겨주시면!! 적극 반영하겠습니다 ㅎㅎ 
