### PR TITLE
[리포트] 리포트의 학습로그 역량을 부모-자식으로 정렬하여 반환한다.  #508

### DIFF
--- a/backend/src/acceptanceTest/java/wooteco/prolog/steps/ReportStepDefinitions.java
+++ b/backend/src/acceptanceTest/java/wooteco/prolog/steps/ReportStepDefinitions.java
@@ -91,7 +91,7 @@ public class ReportStepDefinitions extends AcceptanceSteps {
     @Then("리포트가 수정된다")
     public void 리포트가수정된다() {
         int status = context.response.statusCode();
-        assertThat(status).isEqualTo(200);
+         assertThat(status).isEqualTo(200);
 
         ReportResponse reportResponse = context.response.as(ReportResponse.class);
 
@@ -105,10 +105,10 @@ public class ReportStepDefinitions extends AcceptanceSteps {
             new GraphResponse(
                 Arrays.asList(
                     new GraphAbilityResponse(
-                        1L, "프로그래밍", "red", 2L, 0.0, false
+                        3L, "디자인", "blue", 2L, 1.0, true
                     ),
                     new GraphAbilityResponse(
-                        3L, "디자인", "blue", 2L, 1.0, true
+                        1L, "프로그래밍", "red", 2L, 0.0, false
                     )
                 )
             ),

--- a/backend/src/main/java/wooteco/prolog/report/application/dto/report/ReportAssembler.java
+++ b/backend/src/main/java/wooteco/prolog/report/application/dto/report/ReportAssembler.java
@@ -1,5 +1,6 @@
 package wooteco.prolog.report.application.dto.report;
 
+import static java.util.Comparator.comparing;
 import static java.util.stream.Collectors.toList;
 
 import java.util.List;
@@ -112,7 +113,7 @@ public class ReportAssembler {
             .collect(toList());
 
         Studylog studylog = studylogRepository.findById(reportedStudylog.getStudylogId())
-                .orElseThrow(IllegalArgumentException::new);
+            .orElseThrow(IllegalArgumentException::new);
 
         return new StudylogResponse(
             studylog.getId(),
@@ -136,6 +137,8 @@ public class ReportAssembler {
 
     private GraphResponse of(AbilityGraph abilityGraph) {
         List<GraphAbilityResponse> graphAbilityRespons = abilityGraph.getAbilities().stream()
+            .sorted(comparing(GraphAbilityDto::getColor)
+                .thenComparing(graphAbilityDto -> !graphAbilityDto.isParent()))
             .map(this::of)
             .collect(toList());
 

--- a/backend/src/main/java/wooteco/prolog/report/domain/report/abilitygraph/GraphAbilities.java
+++ b/backend/src/main/java/wooteco/prolog/report/domain/report/abilitygraph/GraphAbilities.java
@@ -52,6 +52,7 @@ public class GraphAbilities {
                 ability.getColor(),
                 ability.getWeight(),
                 calculatePercentage(allWeight, ability),
+                ability.isParent(),
                 ability.isPresent()
             )).collect(toList());
     }

--- a/backend/src/main/java/wooteco/prolog/report/domain/report/abilitygraph/datastructure/GraphAbilityDto.java
+++ b/backend/src/main/java/wooteco/prolog/report/domain/report/abilitygraph/datastructure/GraphAbilityDto.java
@@ -7,14 +7,22 @@ public class GraphAbilityDto {
     private String color;
     private Long weight;
     private Double percentage;
+    private Boolean isParent;
     private Boolean isPresent;
 
-    public GraphAbilityDto(Long id, String name, String color, Long weight, Double percentage, Boolean isPresent) {
+    public GraphAbilityDto(Long id,
+                           String name,
+                           String color,
+                           Long weight,
+                           Double percentage,
+                           Boolean isParent,
+                           Boolean isPresent) {
         this.id = id;
         this.name = name;
         this.color = color;
         this.weight = weight;
         this.percentage = percentage;
+        this.isParent = isParent;
         this.isPresent = isPresent;
     }
 
@@ -36,6 +44,10 @@ public class GraphAbilityDto {
 
     public Double getPercentage() {
         return percentage;
+    }
+
+    public Boolean isParent() {
+        return isParent;
     }
 
     public Boolean isPresent() {

--- a/backend/src/test/java/wooteco/prolog/common/fixture/ability/AbilityFixture.java
+++ b/backend/src/test/java/wooteco/prolog/common/fixture/ability/AbilityFixture.java
@@ -23,21 +23,21 @@ public class AbilityFixture {
                 member);
     }
 
-    public static Ability childAbility1(Member member) {
+    public static Ability childAbility1(Member member, Ability ability) {
         return Ability
-            .parent("test child ability1", "test child ability description1", "test color1",
+            .child("test child ability1", "test child ability description1", "test color1", ability,
                 member);
     }
 
-    public static Ability childAbility2(Member member) {
+    public static Ability childAbility2(Member member, Ability ability) {
         return Ability
-            .parent("test child ability2", "test child ability description2", "test color2",
+            .child("test child ability2", "test child ability description2", "test color2", ability,
                 member);
     }
 
-    public static Ability childAbility3(Member member) {
+    public static Ability childAbility3(Member member, Ability ability) {
         return Ability
-            .parent("test child ability3", "test child ability description3", "test color3",
+            .child("test child ability3", "test child ability description3", "test color3", ability,
                 member);
     }
 }

--- a/backend/src/test/java/wooteco/prolog/studylog/application/ReportServiceTest.java
+++ b/backend/src/test/java/wooteco/prolog/studylog/application/ReportServiceTest.java
@@ -29,6 +29,7 @@ import wooteco.prolog.report.application.ReportService;
 import wooteco.prolog.report.application.dto.report.ReportAssembler;
 import wooteco.prolog.report.application.dto.report.request.ReportRequest;
 import wooteco.prolog.report.application.dto.report.response.ReportResponse;
+import wooteco.prolog.report.domain.ablity.Ability;
 import wooteco.prolog.studylog.domain.Level;
 import wooteco.prolog.studylog.domain.Mission;
 import wooteco.prolog.studylog.domain.Studylog;
@@ -153,9 +154,12 @@ class ReportServiceTest {
     }
 
     private void setAbilities(Member member) {
-        abilityRepository.save(AbilityFixture.parentAbility1(member));
-        abilityRepository.save(AbilityFixture.parentAbility2(member));
-        abilityRepository.save(AbilityFixture.parentAbility3(member));
+        Ability parent1 = abilityRepository.save(AbilityFixture.parentAbility1(member));
+        abilityRepository.save(AbilityFixture.childAbility1(member, parent1));
+        Ability parent2 = abilityRepository.save(AbilityFixture.parentAbility2(member));
+        abilityRepository.save(AbilityFixture.childAbility2(member, parent2));
+        Ability parent3 = abilityRepository.save(AbilityFixture.parentAbility3(member));
+        abilityRepository.save(AbilityFixture.childAbility3(member, parent3));
     }
 
     private void setStudylogs(Member member) {

--- a/backend/src/test/java/wooteco/prolog/studylog/domain/repository/ReportRepositoryTest.java
+++ b/backend/src/test/java/wooteco/prolog/studylog/domain/repository/ReportRepositoryTest.java
@@ -104,8 +104,8 @@ class ReportRepositoryTest {
 
         Level level1 = levelRepository.save(LevelFixture.level1());
         Mission mission = missionRepository.save(MissionFixture.mission1(level1));
-        Ability ability4 = abilityRepository.save(AbilityFixture.childAbility1(member));
-        Ability ability5 = abilityRepository.save(AbilityFixture.childAbility2(member));
+        Ability ability4 = abilityRepository.save(AbilityFixture.childAbility1(member, ability1));
+        Ability ability5 = abilityRepository.save(AbilityFixture.childAbility2(member, ability2));
         Studylog studylog = studylogRepository.save(createStudyLog(member, mission));
         ReportedStudylogs reportedStudylogs = new ReportedStudylogs(Arrays.asList(
             new ReportedStudylog(

--- a/backend/src/test/resources/jsons/report_post_request.json
+++ b/backend/src/test/resources/jsons/report_post_request.json
@@ -17,6 +17,21 @@
         "id": 3,
         "weight": 1,
         "isPresent":false
+      },
+      {
+        "id": 4,
+        "weight": 1,
+        "isPresent":false
+      },
+      {
+        "id": 5,
+        "weight": 1,
+        "isPresent":false
+      },
+      {
+        "id": 6,
+        "weight": 1,
+        "isPresent":false
       }
     ]
   },

--- a/backend/src/test/resources/jsons/report_post_response.json
+++ b/backend/src/test/resources/jsons/report_post_response.json
@@ -2,32 +2,56 @@
   "id": 1,
   "title": "simple report",
   "description": "report for test",
-  "createdAt": null,
-  "updatedAt": null,
+  "createdAt": "2021-10-19T02:28:35.582",
+  "updatedAt": "2021-10-19T02:28:35.582",
   "abilityGraph": {
     "abilities": [
       {
         "id": 1,
         "name": "test parent ability1",
-        "color" : "test color1",
+        "color": "test color1",
         "weight": 1,
         "percentage": 0.5,
         "isPresent": true
       },
       {
         "id": 2,
-        "name": "test parent ability2",
-        "color" : "test color2",
+        "name": "test child ability1",
+        "color": "test color1",
         "weight": 1,
         "percentage": 0.5,
         "isPresent": true
       },
       {
         "id": 3,
+        "name": "test parent ability2",
+        "color": "test color2",
+        "weight": 1,
+        "percentage": 0,
+        "isPresent": false
+      },
+      {
+        "id": 4,
+        "name": "test child ability2",
+        "color": "test color2",
+        "weight": 1,
+        "percentage": 0,
+        "isPresent": false
+      },
+      {
+        "id": 5,
         "name": "test parent ability3",
         "color": "test color3",
         "weight": 1,
-        "percentage": 0.0,
+        "percentage": 0,
+        "isPresent": false
+      },
+      {
+        "id": 6,
+        "name": "test child ability3",
+        "color": "test color3",
+        "weight": 1,
+        "percentage": 0,
         "isPresent": false
       }
     ]
@@ -35,8 +59,8 @@
   "studylogs": [
     {
       "id": 1,
-      "createAt": "2021-09-21T20:58:20.601485",
-      "updateAt": "2021-09-21T20:58:20.601485",
+      "createAt": "2021-10-19T02:28:35.565",
+      "updateAt": "2021-10-19T02:28:35.565",
       "title": "title",
       "abilities": [
         {
@@ -47,9 +71,9 @@
         },
         {
           "id": 2,
-          "name": "test parent ability2",
-          "color": "test color2",
-          "parent": true
+          "name": "test child ability1",
+          "color": "test color1",
+          "parent": false
         }
       ]
     }

--- a/backend/src/test/resources/jsons/report_put_response.json
+++ b/backend/src/test/resources/jsons/report_put_response.json
@@ -2,20 +2,22 @@
   "id": 1,
   "title": "simple report2",
   "description": "report for test2",
+  "createdAt": "2021-10-19T02:30:25.236",
+  "updatedAt": "2021-10-19T02:30:25.236",
   "abilityGraph": {
     "abilities": [
       {
         "id": 1,
         "name": "test parent ability1",
-        "color" : "test color1",
+        "color": "test color1",
         "weight": 2,
         "percentage": 0.67,
         "isPresent": true
       },
       {
         "id": 3,
-        "name": "test parent ability3",
-        "color": "test color3",
+        "name": "test parent ability2",
+        "color": "test color2",
         "weight": 1,
         "percentage": 0.33,
         "isPresent": true
@@ -25,8 +27,8 @@
   "studylogs": [
     {
       "id": 1,
-      "createAt": "2021-09-21T22:08:29.819053",
-      "updateAt": "2021-09-21T22:08:29.819053",
+      "createAt": "2021-10-19T02:30:25.22",
+      "updateAt": "2021-10-19T02:30:25.22",
       "title": "title",
       "abilities": [
         {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/33603557/137780945-12e47101-1745-4fdf-8544-bb82431fa65d.png)

(색, 상위하위) 로 정렬되도록 하였습니다.

close #508 