### PR TITLE
fix: 토큰 만료 및 유효하지 않을 시 gnb 영역의 상태가 변하지 않는 이슈 수정

### DIFF
--- a/frontend/src/components/NavBar/NavBar.js
+++ b/frontend/src/components/NavBar/NavBar.js
@@ -41,7 +41,7 @@ const NavBar = () => {
 
   useEffect(() => {
     if (accessToken) {
-      dispatch(getProfile(accessToken));
+      dispatch(getProfile());
     }
 
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/frontend/src/constants/api.js
+++ b/frontend/src/constants/api.js
@@ -1,7 +1,7 @@
 const API = {
   ACCESS_TOKEN: 'accessToken',
   STATUS: {
-    EXPIRED_ACCESS_TOKEN: 500,
+    EXPIRED_ACCESS_TOKEN: 1002,
   },
 };
 

--- a/frontend/src/hooks/useRequest.js
+++ b/frontend/src/hooks/useRequest.js
@@ -4,9 +4,9 @@ const useRequest = (defaultValue, callback, onSuccess, onError, onFinish) => {
   const [response, setResponse] = useState(defaultValue);
   const [error, setError] = useState('');
 
-  const fetchData = async () => {
+  const fetchData = async (data) => {
     try {
-      const response = await callback();
+      const response = await callback(data);
 
       if (!response.ok) {
         throw new Error(await response.text());

--- a/frontend/src/pages/ProfilePageReports/index.js
+++ b/frontend/src/pages/ProfilePageReports/index.js
@@ -33,7 +33,6 @@ const ProfilePageReports = () => {
     {},
     () => requestGetReport(reportId),
     (data) => {
-      console.log(data);
       setReportName(data.title);
     },
     () => {
@@ -46,7 +45,7 @@ const ProfilePageReports = () => {
     [],
     () => requestGetReportList({ username, type: REQUEST_REPORT_TYPE.SIMPLE }),
     (data) => {
-      const reportName = data.find((report) => report.id === Number(reportId)).title;
+      const reportName = data.reports.find((report) => report.id === Number(reportId)).title;
 
       setReportName(reportName);
     }

--- a/frontend/src/pages/ProfilePageReportsList/index.tsx
+++ b/frontend/src/pages/ProfilePageReportsList/index.tsx
@@ -158,11 +158,13 @@ const ProfilePageReportsList = () => {
                 <p>{description}</p>
 
                 <AbilityList>
-                  {abilityGraph.abilities.map(({ id, name }: Ability) => (
-                    <li key={id}>
-                      <Chip backgroundColor={`${COLOR.LIGHT_BLUE_100}`}>{name}</Chip>
-                    </li>
-                  ))}
+                  {abilityGraph.abilities
+                    .filter(({ isPresent }) => isPresent)
+                    .map(({ id, name }: Ability) => (
+                      <li key={id}>
+                        <Chip backgroundColor={`${COLOR.LIGHT_BLUE_100}`}>{name}</Chip>
+                      </li>
+                    ))}
                 </AbilityList>
 
                 <StudyLogCount>

--- a/frontend/src/redux/actions/userAction.js
+++ b/frontend/src/redux/actions/userAction.js
@@ -44,7 +44,7 @@ export const login = () => async (dispatch) => {
   }
 };
 
-export const getProfile = (accessToken) => async (dispatch) => {
+export const getProfile = () => async (dispatch) => {
   dispatch({ type: GET_PROFILE });
   const accessToken = ls.get(API.ACCESS_TOKEN);
 
@@ -56,9 +56,7 @@ export const getProfile = (accessToken) => async (dispatch) => {
       },
     });
 
-    const status = response.status;
-
-    if (status === API.STATUS.EXPIRED_ACCESS_TOKEN) {
+    if (!response.ok) {
       throw new Error(await response.text());
     }
 


### PR DESCRIPTION
fix #513 

토큰 만료 및 유효하지 않을 시 gnb 영역의 상태가 변하지 않는 이슈를 수정하였습니다.

해당 부분은 초기 api 에서 유효하지 않은 상태의 jwt일 때 api error code를 500으로 받아서 분기 처리를 하는 부분에서 발생한 이슈로, 해당 부분을 !response.ok 로 처리하였고, api.js 문서의 상태코드를 수정해두었습니다