### PR TITLE
[리포트] 특정 상황에서 역량이 삭제되지 않는 문제를 해결한다. #538

### DIFF
--- a/backend/src/main/java/wooteco/prolog/report/domain/report/abilitygraph/GraphAbility.java
+++ b/backend/src/main/java/wooteco/prolog/report/domain/report/abilitygraph/GraphAbility.java
@@ -10,6 +10,8 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import lombok.AllArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 import wooteco.prolog.report.domain.ablity.Ability;
 import wooteco.prolog.report.domain.report.common.Updatable;
 
@@ -21,6 +23,7 @@ public class GraphAbility implements Updatable<GraphAbility> {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @OnDelete(action = OnDeleteAction.CASCADE)
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "ability_id", nullable = false)
     private Ability ability;

--- a/backend/src/main/resources/db/migration/prod/V7__add_on_delete_cascade_to_report.sql
+++ b/backend/src/main/resources/db/migration/prod/V7__add_on_delete_cascade_to_report.sql
@@ -1,0 +1,8 @@
+alter table graph_ability
+    drop foreign key FK_GRAPH_ABILITY_ABILITY;
+
+alter table graph_ability
+    add constraint FK_GRAPH_ABILITY_ABILITY_WITH_ON_DELETE_CASCADE
+        foreign key (ability_id)
+            references ability (id) ON DELETE CASCADE;
+


### PR DESCRIPTION
문제 상황
- 리포트를 등록한 후 리포트에 등록되지 않은 역량 삭제 시 오류 발생

해결 
- 역량 그래프와 역량간의 FK 제약조건으로 인해 역량 삭제 시 무결성 오류 발생
- on delete cascade를 추가하여 해결


close #538