### PR TITLE
refactor: @MemberOnly 에 LoginMember 없어도 되게끔 수정

### DIFF
--- a/backend/src/main/java/wooteco/prolog/login/aop/LoginMemberVerifier.java
+++ b/backend/src/main/java/wooteco/prolog/login/aop/LoginMemberVerifier.java
@@ -1,25 +1,24 @@
 package wooteco.prolog.login.aop;
 
-import java.util.Arrays;
-import org.aspectj.lang.JoinPoint;
+import lombok.RequiredArgsConstructor;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Before;
 import org.springframework.stereotype.Component;
-import wooteco.prolog.login.ui.LoginMember;
+import wooteco.prolog.login.ui.LoginMember.Authority;
 import wooteco.prolog.member.exception.MemberNotAllowedException;
 
 @Aspect
 @Component
+@RequiredArgsConstructor
 public class LoginMemberVerifier {
 
-    @Before("@annotation(wooteco.prolog.login.aop.MemberOnly)")
-    public void checkLoginMember(JoinPoint joinPoint) {
-        final LoginMember loginMember = (LoginMember) Arrays.stream(joinPoint.getArgs())
-            .filter(argument -> argument instanceof LoginMember)
-            .findAny()
-            .orElseThrow(() -> new IllegalStateException("LoginMember 가 존재하지 않습니다."));
+    private final MemberAuthorityCache memberAuthorityCache;
 
-        loginMember.act()
-            .throwIfAnonymous(MemberNotAllowedException::new);
+    @Before("@annotation(wooteco.prolog.login.aop.MemberOnly)")
+    public void checkLoginMember() {
+        final Authority authority = memberAuthorityCache.getAuthority();
+        if (!authority.equals(Authority.MEMBER)) {
+            throw new MemberNotAllowedException();
+        }
     }
 }

--- a/backend/src/main/java/wooteco/prolog/login/aop/MemberAuthorityCache.java
+++ b/backend/src/main/java/wooteco/prolog/login/aop/MemberAuthorityCache.java
@@ -1,0 +1,20 @@
+package wooteco.prolog.login.aop;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.annotation.RequestScope;
+import wooteco.prolog.login.ui.LoginMember.Authority;
+
+@Component
+@RequestScope
+public class MemberAuthorityCache {
+
+    private Authority authority;
+
+    public Authority getAuthority() {
+        return authority;
+    }
+
+    public void setAuthority(Authority authority) {
+        this.authority = authority;
+    }
+}


### PR DESCRIPTION
## resolved #566 

빈 스코프(`Request`)를 이용해 `@MemberOnly` 어노테이션을 사용해도 `LoginMember`를 안 넣어도 될 수 있게끔 수정한다.

### 생각했던 해결 방안들
1. 가지고 있는 `WebRequest` 정보를 가져와 다시 토큰의 페이로드를 분석한다 
       -> 두 번의 토큰 확인 작업이 이뤄나서 패스!
2. `LoginMember` 자체를 `Request` 스코프 빈으로 지정해 해결한다.
       -> 스코프를 따로 주어 사용 시 프록시를 이용하게 되는데 getter 와 같이 값을 가져와야지만 내부 값을 읽을 수 있게됨. 즉, 내부에서 값을 
            비교 시 비어있기에 올바른 비교가 힘듬. 예를 들어, `LoginMember.isMember()` 는 내부에서 값을 비교하기에 계속 `false`. 
            getter 를 이용해 해결할 수 있지만 다른 곳에서도 계속 이런 조심을 해야하기에 패스!
3. `LoginMember` 와 관련 없는 `MemberAuthorityCache` 로 관리. -> 채택

다른 아이디어 있으신다면 언제든 이야기해주세요~!!