### PR TITLE
feat: 리포트 학습로그 목록에 역량을 추가한다.

### DIFF
--- a/frontend/src/components/Chip/Chip.js
+++ b/frontend/src/components/Chip/Chip.js
@@ -10,6 +10,7 @@ const Chip = ({
   width,
   color,
   backgroundColor,
+  fontSize,
   onDelete,
   children,
 }) => {
@@ -21,7 +22,9 @@ const Chip = ({
       color={color}
       backgroundColor={backgroundColor}
     >
-      <ChipText textAlign={textAlign}>{children}</ChipText>
+      <ChipText textAlign={textAlign} fontSize={fontSize}>
+        {children}
+      </ChipText>
       {onDelete && (
         <button type="button" onClick={onDelete}>
           <CancelIcon width="10px" height="10px" strokeWidth="2px" stroke={COLOR.BLACK_900} />
@@ -38,6 +41,7 @@ Chip.propTypes = {
   width: PropTypes.string,
   color: PropTypes.string,
   backgroundColor: PropTypes.string,
+  fontSize: PropTypes.string,
   onDelete: PropTypes.func,
   children: PropTypes.node,
 };

--- a/frontend/src/components/Chip/Chip.styles.js
+++ b/frontend/src/components/Chip/Chip.styles.js
@@ -44,8 +44,9 @@ const Container = styled.div`
 `;
 
 const ChipText = styled.span`
-  font-size: 1.4rem;
   text-align: ${({ textAlign }) => (textAlign ? textAlign : 'center')};
+  font-size: ${({ fontSize }) => (fontSize ? fontSize : '1.4rem')};
+
   color: inherit;
 
   overflow: hidden;

--- a/frontend/src/pages/ProfilePageEditReport/index.js
+++ b/frontend/src/pages/ProfilePageEditReport/index.js
@@ -27,6 +27,7 @@ const ProfilePageEditReport = () => {
   const [description, setDescription] = useState('');
   const [studyLogs, setStudyLogs] = useState([]);
   const [abilities, setAbilities] = useState([]);
+  const [studyLogAbilities, setStudyLogAbilities] = useState([]);
   const [isModalOpened, setIsModalOpened] = useState(false);
 
   useEffect(() => {
@@ -58,6 +59,12 @@ const ProfilePageEditReport = () => {
       setDescription(report.description);
       setStudyLogs(report.studylogs);
       setAbilities(report.abilityGraph.abilities);
+      report.studylogs.forEach((reportStudyLog) => {
+        setStudyLogAbilities((currStudyLogAbilities) => [
+          ...currStudyLogAbilities,
+          { id: reportStudyLog.id, abilities: reportStudyLog.abilities },
+        ]);
+      });
     } catch (error) {
       console.error(error);
       history.push(`/${username}/reports`);
@@ -82,6 +89,14 @@ const ProfilePageEditReport = () => {
     }
   };
 
+  const getCheckedAbility = (studyLogId) => {
+    const targetStudyLogAbility = studyLogAbilities.find(
+      (studyLogAbility) => studyLogAbility.id === studyLogId
+    )?.abilities;
+
+    return targetStudyLogAbility?.map((ability) => ability.id) ?? [];
+  };
+
   const onSubmitReport = (event) => {
     event.preventDefault();
 
@@ -92,7 +107,11 @@ const ProfilePageEditReport = () => {
       abilityGraph: {
         abilities: abilities.map(({ id, weight, isPresent }) => ({ id, weight, isPresent })),
       },
-      studylogs: studyLogs.map((item) => ({ id: item.id, abilities: [] })),
+      // studylogs: studyLogs.map((item) => ({ id: item.id, abilities: [] })),
+      studylogs: studyLogs.map((item) => ({
+        id: item.id,
+        abilities: getCheckedAbility(item.id),
+      })),
       represent: isMainReport,
     };
 
@@ -145,6 +164,9 @@ const ProfilePageEditReport = () => {
           onModalOpen={onModalOpen}
           studyLogs={studyLogs}
           setStudyLogs={setStudyLogs}
+          abilities={abilities}
+          studyLogAbilities={studyLogAbilities}
+          setStudyLogAbilities={setStudyLogAbilities}
         />
 
         <FormButtonWrapper>

--- a/frontend/src/pages/ProfilePageNewReport/ReportStudyLogTable.js
+++ b/frontend/src/pages/ProfilePageNewReport/ReportStudyLogTable.js
@@ -73,14 +73,18 @@ const ReportStudyLogTable = ({
   const onDeleteStudyLogInReport = () => {
     if (allChecked) {
       const moveTargetPage = currPage === totalPage ? currPage - 1 : currPage;
+      setStudyLogAbilities([]);
       setPage(moveTargetPage);
     }
 
     setStudyLogs((currStudyLogs) => filterOnlyNewList(currStudyLogs, deleteTargets));
+    setStudyLogAbilities((currStudyLogAbility) =>
+      filterOnlyNewList(currStudyLogAbility, deleteTargets)
+    );
     setDeleteTargets([]);
   };
 
-  // 페이지네이동
+  // 페이지 이동
   const onMoveToPage = (number) => {
     setDeleteTargets([]);
     setPage(number);

--- a/frontend/src/pages/ProfilePageNewReport/ReportStudyLogTable.js
+++ b/frontend/src/pages/ProfilePageNewReport/ReportStudyLogTable.js
@@ -105,7 +105,9 @@ const ReportStudyLogTable = ({
 
     return targetStudyLogAbilities?.abilities?.map((ability) => (
       <li key={ability.id}>
-        <Chip backgroundColor={ability.color}>{ability.name}</Chip>
+        <Chip backgroundColor={ability.color} fontSize="1.2rem">
+          {ability.name}
+        </Chip>
       </li>
     ));
   };

--- a/frontend/src/pages/ProfilePageNewReport/ReportStudyLogTable.js
+++ b/frontend/src/pages/ProfilePageNewReport/ReportStudyLogTable.js
@@ -158,6 +158,17 @@ const ReportStudyLogTable = ({
     }
   };
 
+  const isChecked = (studyLogId, abilityId) => {
+    //studyLog에 Ability가 잉ㅆ는가?
+    const targetStudyLog = studyLogAbilities?.find(
+      (studyLogAbility) => studyLogAbility.id === studyLogId
+    );
+
+    if (!targetStudyLog) return false;
+
+    return targetStudyLog.abilities.map((ability) => Number(ability.id)).includes(abilityId);
+  };
+
   return (
     <Section>
       <h3>📚 학습로그 목록</h3>
@@ -217,15 +228,7 @@ const ReportStudyLogTable = ({
                 </a>
               </td>
               <td>
-                <ul>
-                  {selectedAbilities(id)}
-
-                  {/* {
-                    <li key={ability.id}>
-                      <Chip backgroundColor={ability.color}>{ability.name}</Chip>
-                    </li>
-                  } */}
-                </ul>
+                <ul>{selectedAbilities(id)}</ul>
                 <Button
                   size="XX_SMALL"
                   type="button"
@@ -245,6 +248,7 @@ const ReportStudyLogTable = ({
                                 <input
                                   type="checkbox"
                                   onChange={() => onAddAbilities(id, ability)}
+                                  checked={isChecked(id, ability.id)}
                                 />
                                 <span>{ability.name}</span>
                               </label>

--- a/frontend/src/pages/ProfilePageNewReport/ReportStudyLogTable.js
+++ b/frontend/src/pages/ProfilePageNewReport/ReportStudyLogTable.js
@@ -89,6 +89,7 @@ const ReportStudyLogTable = ({ onModalOpen, studyLogs, setStudyLogs }) => {
               />
             </th>
             <th scope="col">제목</th>
+            <th scope="col">역량</th>
           </tr>
         </Thead>
 
@@ -107,6 +108,18 @@ const ReportStudyLogTable = ({ onModalOpen, studyLogs, setStudyLogs }) => {
                 <a href={`/posts/${id}`} target="_blank" rel="noopener noreferrer">
                   {title}
                 </a>
+              </td>
+              <td>
+                <ul>
+                  <li></li>
+                </ul>
+                <Button
+                  size="XX_SMALL"
+                  type="button"
+                  css={{ backgroundColor: `${COLOR.LIGHT_BLUE_300}` }}
+                >
+                  +
+                </Button>
               </td>
             </tr>
           ))}

--- a/frontend/src/pages/ProfilePageNewReport/ReportStudyLogTable.js
+++ b/frontend/src/pages/ProfilePageNewReport/ReportStudyLogTable.js
@@ -256,7 +256,7 @@ const ReportStudyLogTable = ({
                                   onChange={() => onAddAbilities(id, ability)}
                                   checked={isChecked(id, ability.id)}
                                 />
-                                <span>{ability.name}</span>
+                                <Chip backgroundColor={ability.color}>{ability.name}</Chip>
                               </label>
                             </li>
                           )

--- a/frontend/src/pages/ProfilePageNewReport/ReportStudyLogTable.js
+++ b/frontend/src/pages/ProfilePageNewReport/ReportStudyLogTable.js
@@ -1,9 +1,9 @@
-import React, { useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 
 import { onToggleCheckbox } from '../../utils/toggleCheckbox';
 import { filterOnlyNewList } from '../../utils/filteringList';
 import useReportStudyLogs from '../../hooks/useReportStudyLogs';
-import { Button, Pagination } from '../../components';
+import { Button, Chip, Pagination } from '../../components';
 import COLOR from '../../constants/color';
 import { Checkbox } from './style';
 import {
@@ -13,15 +13,47 @@ import {
   Tbody,
   Thead,
   EmptyTableGuide,
+  SelectAbilityBox,
 } from './ReportStudyLogTable.styles';
 
-const ReportStudyLogTable = ({ onModalOpen, studyLogs, setStudyLogs }) => {
+const ReportStudyLogTable = ({
+  onModalOpen,
+  studyLogs,
+  setStudyLogs,
+  abilities,
+  studyLogAbilities,
+  setStudyLogAbilities,
+}) => {
   const { reportStudyLogData, setPage } = useReportStudyLogs(studyLogs);
   const { currPage, totalPage, totalSize, data: currReportStudyLogs } = reportStudyLogData;
+
   const [deleteTargets, setDeleteTargets] = useState([]);
+  const [selectAbilityBox, setSelectAbilityBox] = useState({
+    id: 0,
+    state: false,
+  });
 
+  const selectAbilityBoxRef = useRef(null);
+
+  // 역량선택 모달 닫기 관련
+  useEffect(() => {
+    const onCloseOptionList = (event) => {
+      if (!selectAbilityBox) return;
+
+      if (!selectAbilityBoxRef.current?.contains(event.target)) {
+        setSelectAbilityBox({ ...selectAbilityBox, state: false });
+      }
+    };
+
+    document.addEventListener('click', onCloseOptionList);
+
+    return () => {
+      document.removeEventListener('click', onCloseOptionList);
+    };
+  }, [selectAbilityBox, selectAbilityBoxRef]);
+
+  // 학습로그 표 전체삭제
   const allChecked = deleteTargets?.length === currReportStudyLogs?.length;
-
   const onToggleAllStudyLog = () => {
     if (allChecked) {
       setDeleteTargets([]);
@@ -30,12 +62,14 @@ const ReportStudyLogTable = ({ onModalOpen, studyLogs, setStudyLogs }) => {
     }
   };
 
+  // 학습로그 목록 체크박스
   const onToggleStudyLog = (id) => {
     const targetStudyLog = studyLogs.find((studyLog) => studyLog.id === id);
 
     setDeleteTargets(onToggleCheckbox(deleteTargets, targetStudyLog));
   };
 
+  // 학습로그 삭제
   const onDeleteStudyLogInReport = () => {
     if (allChecked) {
       const moveTargetPage = currPage === totalPage ? currPage - 1 : currPage;
@@ -46,9 +80,82 @@ const ReportStudyLogTable = ({ onModalOpen, studyLogs, setStudyLogs }) => {
     setDeleteTargets([]);
   };
 
+  // 페이지네이동
   const onMoveToPage = (number) => {
     setDeleteTargets([]);
     setPage(number);
+  };
+
+  // 역량 목록 열기
+  const onOpenAbilityBox = (event, id) => {
+    event.stopPropagation();
+
+    setSelectAbilityBox({ id, state: true });
+  };
+
+  // 선택된 역량 추가
+  const selectedAbilities = (studyLogId) => {
+    const targetStudyLogAbilities = studyLogAbilities.find(
+      (studyLogAbility) => studyLogAbility.id === studyLogId
+    );
+
+    return targetStudyLogAbilities?.abilities?.map((ability) => (
+      <li key={ability.id}>
+        <Chip backgroundColor={ability.color}>{ability.name}</Chip>
+      </li>
+    ));
+  };
+
+  // 학습로그 목록에 역량 추가
+  const onAddAbilities = (studyLogId, currAbility) => {
+    const targetStudyLogAbility = studyLogAbilities?.find(
+      (studyLogAbility) => studyLogAbility.id === studyLogId
+    );
+
+    if (!targetStudyLogAbility) {
+      setStudyLogAbilities((currStudyLog) => [
+        ...currStudyLog,
+        {
+          id: studyLogId,
+          abilities: [currAbility],
+        },
+      ]);
+    } else {
+      const index = studyLogAbilities
+        .map((studyLog) => studyLog.id)
+        .indexOf(targetStudyLogAbility.id);
+
+      if (targetStudyLogAbility.abilities.find((ability) => ability.id === currAbility.id)) {
+        const abilityIndex = targetStudyLogAbility.abilities
+          .map((ability) => ability.id)
+          .indexOf(currAbility.id);
+
+        const deleteStudyLogAbility = {
+          id: studyLogId,
+          abilities: [
+            ...targetStudyLogAbility.abilities.slice(0, abilityIndex),
+            ...targetStudyLogAbility.abilities.slice(abilityIndex + 1),
+          ],
+        };
+
+        setStudyLogAbilities([
+          ...studyLogAbilities.slice(0, index),
+          deleteStudyLogAbility,
+          ...studyLogAbilities.slice(index + 1),
+        ]);
+      } else {
+        const addStudyLogAbiliityResult = {
+          id: studyLogId,
+          abilities: [...targetStudyLogAbility.abilities, currAbility],
+        };
+
+        setStudyLogAbilities([
+          ...studyLogAbilities.slice(0, index),
+          addStudyLogAbiliityResult,
+          ...studyLogAbilities.slice(index + 1),
+        ]);
+      }
+    }
   };
 
   return (
@@ -111,15 +218,42 @@ const ReportStudyLogTable = ({ onModalOpen, studyLogs, setStudyLogs }) => {
               </td>
               <td>
                 <ul>
-                  <li></li>
+                  {selectedAbilities(id)}
+
+                  {/* {
+                    <li key={ability.id}>
+                      <Chip backgroundColor={ability.color}>{ability.name}</Chip>
+                    </li>
+                  } */}
                 </ul>
                 <Button
                   size="XX_SMALL"
                   type="button"
                   css={{ backgroundColor: `${COLOR.LIGHT_BLUE_300}` }}
+                  onClick={(event) => onOpenAbilityBox(event, id)}
                 >
                   +
                 </Button>
+                {selectAbilityBox.id === id && selectAbilityBox.state && (
+                  <SelectAbilityBox ref={selectAbilityBoxRef}>
+                    <ul>
+                      {abilities?.map(
+                        (ability) =>
+                          ability.isPresent && (
+                            <li key={ability.id}>
+                              <label>
+                                <input
+                                  type="checkbox"
+                                  onChange={() => onAddAbilities(id, ability)}
+                                />
+                                <span>{ability.name}</span>
+                              </label>
+                            </li>
+                          )
+                      )}
+                    </ul>
+                  </SelectAbilityBox>
+                )}
               </td>
             </tr>
           ))}

--- a/frontend/src/pages/ProfilePageNewReport/ReportStudyLogTable.styles.js
+++ b/frontend/src/pages/ProfilePageNewReport/ReportStudyLogTable.styles.js
@@ -93,19 +93,22 @@ const Thead = styled.thead`
 
 const Tbody = styled.tbody`
   display: block;
-  min-height: 15rem;
+  min-height: 10rem;
 
   tr {
     width: 96%;
     border-bottom: 0.1rem solid ${COLOR.LIGHT_GRAY_300};
+    height: 6rem;
     margin: 0 auto;
 
     td:nth-of-type(1) {
+      height: 100%;
       width: 6%;
       text-align: center;
     }
 
     td:nth-of-type(2) {
+      height: 100%;
       width: 47%;
       overflow: hidden;
       text-overflow: ellipsis;
@@ -120,22 +123,22 @@ const Tbody = styled.tbody`
     }
 
     td:nth-of-type(3) {
+      height: 100%;
       display: flex;
       justify-content: space-between;
       align-items: center;
 
       ul {
         width: 90%;
+        height: 100%;
         margin-right: 1.5rem;
         overflow: auto;
 
-        li {
-          display: inline;
-          margin-right: 1.5rem;
-        }
+        display: flex;
+        align-items: center;
 
-        ::-webkit-scrollbar {
-          display: none;
+        li {
+          height: fit-content;
         }
       }
 

--- a/frontend/src/pages/ProfilePageNewReport/ReportStudyLogTable.styles.js
+++ b/frontend/src/pages/ProfilePageNewReport/ReportStudyLogTable.styles.js
@@ -185,7 +185,9 @@ const SelectAbilityBox = styled.div`
 
       label {
         width: 100%;
-        display: block;
+
+        display: flex;
+        align-items: center;
       }
 
       input {

--- a/frontend/src/pages/ProfilePageNewReport/ReportStudyLogTable.styles.js
+++ b/frontend/src/pages/ProfilePageNewReport/ReportStudyLogTable.styles.js
@@ -82,7 +82,11 @@ const Thead = styled.thead`
     }
 
     th:nth-of-type(2) {
-      width: 90%;
+      width: 30%;
+    }
+
+    th:nth-of-type(3) {
+      width: 60%;
     }
   }
 `;
@@ -92,17 +96,17 @@ const Tbody = styled.tbody`
   min-height: 15rem;
 
   tr {
-    width: 98%;
+    width: 96%;
     border-bottom: 0.1rem solid ${COLOR.LIGHT_GRAY_300};
     margin: 0 auto;
 
     td:nth-of-type(1) {
-      width: 8%;
+      width: 6%;
       text-align: center;
     }
 
     td:nth-of-type(2) {
-      width: 92%;
+      width: 47%;
       overflow: hidden;
       text-overflow: ellipsis;
       white-space: nowrap;
@@ -112,6 +116,34 @@ const Tbody = styled.tbody`
         :hover {
           text-decoration: underline;
         }
+      }
+    }
+
+    td:nth-of-type(3) {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+
+      ul {
+        width: 90%;
+        margin-right: 1.5rem;
+        overflow: auto;
+
+        li {
+          display: inline;
+          margin-right: 1.5rem;
+        }
+
+        ::-webkit-scrollbar {
+          display: none;
+        }
+      }
+
+      button {
+        width: 10%;
+        margin-top: 0.1rem;
+        color: ${COLOR.DARK_GRAY_900};
+        font-size: 2rem;
       }
     }
   }

--- a/frontend/src/pages/ProfilePageNewReport/ReportStudyLogTable.styles.js
+++ b/frontend/src/pages/ProfilePageNewReport/ReportStudyLogTable.styles.js
@@ -101,6 +101,8 @@ const Tbody = styled.tbody`
     height: 6rem;
     margin: 0 auto;
 
+    position: relative;
+
     td:nth-of-type(1) {
       height: 100%;
       width: 6%;
@@ -128,7 +130,7 @@ const Tbody = styled.tbody`
       justify-content: space-between;
       align-items: center;
 
-      ul {
+      > ul {
         width: 90%;
         height: 100%;
         margin-right: 1.5rem;
@@ -152,6 +154,47 @@ const Tbody = styled.tbody`
   }
 `;
 
+const SelectAbilityBox = styled.div`
+  width: 20rem;
+  height: 24rem;
+
+  position: absolute;
+  top: 3rem;
+  right: 1rem;
+
+  border: 1px solid ${COLOR.LIGHT_GRAY_800};
+  background-color: ${COLOR.WHITE};
+  border-radius: 1rem;
+
+  z-index: 2;
+
+  ul {
+    width: 100%;
+    height: 100%;
+    padding: 1rem;
+    overflow-y: auto;
+
+    display: flex;
+    flex-direction: column;
+
+    li {
+      width: 100%;
+      padding: 1rem 0;
+
+      border-bottom: 1px solid ${COLOR.LIGHT_GRAY_200};
+
+      label {
+        width: 100%;
+        display: block;
+      }
+
+      input {
+        margin-right: 1rem;
+      }
+    }
+  }
+`;
+
 const EmptyTableGuide = styled.span`
   display: inline-block;
   width: 100%;
@@ -161,4 +204,4 @@ const EmptyTableGuide = styled.span`
   bottom: 30%;
 `;
 
-export { Section, TableButtonWrapper, Table, Thead, Tbody, EmptyTableGuide };
+export { Section, TableButtonWrapper, Table, Thead, Tbody, SelectAbilityBox, EmptyTableGuide };

--- a/frontend/src/pages/ProfilePageNewReport/index.js
+++ b/frontend/src/pages/ProfilePageNewReport/index.js
@@ -39,8 +39,9 @@ const ProfilePageNewReport = () => {
   const [isMainReport, setIsMainReport] = useState(false);
   const [title, setTitle] = useState('');
   const [description, setDescription] = useState('');
-  const [studyLogs, setStudyLogs] = useState([]);
   const [abilities, setAbilities] = useState([]);
+  const [studyLogs, setStudyLogs] = useState([]);
+  const [studyLogAbilities, setStudyLogAbilities] = useState([]);
 
   const [isModalOpened, setIsModalOpened] = useState(false);
 
@@ -80,7 +81,10 @@ const ProfilePageNewReport = () => {
       abilityGraph: {
         abilities: abilities.map(({ id, weight, isPresent }) => ({ id, weight, isPresent })),
       },
-      studylogs: studyLogs.map((item) => ({ id: item.id, abilities: [] })),
+      studylogs: studyLogs.map((item) => ({
+        id: item.id,
+        abilities: item.abilities.map((ability) => ability.id),
+      })),
       represent: isMainReport,
     };
 
@@ -93,7 +97,7 @@ const ProfilePageNewReport = () => {
     }
   };
 
-  const { fetchData: getAbilities } = useRequest(
+  useRequest(
     [],
     () => requestGetAbilities(username, accessToken),
     (data) => {
@@ -150,6 +154,9 @@ const ProfilePageNewReport = () => {
           onModalOpen={onModalOpen}
           studyLogs={studyLogs}
           setStudyLogs={setStudyLogs}
+          abilities={abilities}
+          studyLogAbilities={studyLogAbilities}
+          setStudyLogAbilities={setStudyLogAbilities}
         />
 
         <FormButtonWrapper>

--- a/frontend/src/pages/ProfilePageNewReport/index.js
+++ b/frontend/src/pages/ProfilePageNewReport/index.js
@@ -64,6 +64,14 @@ const ProfilePageNewReport = () => {
     }
   };
 
+  const getCheckedAbility = (studyLogId) => {
+    const targetStudyLogAbility = studyLogAbilities.find(
+      (studyLogAbility) => studyLogAbility.id === studyLogId
+    )?.abilities;
+
+    return targetStudyLogAbility?.map((ability) => ability.id) ?? [];
+  };
+
   const onSubmitReport = async (event) => {
     event.preventDefault();
 
@@ -83,7 +91,7 @@ const ProfilePageNewReport = () => {
       },
       studylogs: studyLogs.map((item) => ({
         id: item.id,
-        abilities: item.abilities.map((ability) => ability.id),
+        abilities: getCheckedAbility(item.id),
       })),
       represent: isMainReport,
     };

--- a/frontend/src/pages/ProfilePageReports/ReportStudyLogTable.js
+++ b/frontend/src/pages/ProfilePageReports/ReportStudyLogTable.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Pagination } from '../../components';
+import { Chip, Pagination } from '../../components';
 import useStudyLogsPagination from '../../hooks/useStudyLogsPagination';
 import { Section, Table, Tbody, Thead, EmptyTableGuide } from './ReportStudyLogTable.styles';
 
@@ -24,11 +24,12 @@ const ReportStudyLogTable = ({ studyLogs }) => {
               <span>번호</span>
             </th>
             <th scope="col">제목</th>
+            <th scope="col">역량</th>
           </tr>
         </Thead>
 
         <Tbody>
-          {currReportStudyLogs.map(({ id, title }, index) => (
+          {currReportStudyLogs.map(({ id, title, abilities }, index) => (
             <tr key={id}>
               <td>
                 <span>{(currPage - 1) * 10 + index + 1}</span>
@@ -37,6 +38,15 @@ const ReportStudyLogTable = ({ studyLogs }) => {
                 <a href={`/posts/${id}`} target="_blank" rel="noopener noreferrer">
                   {title}
                 </a>
+              </td>
+              <td>
+                <ul>
+                  {abilities.map((ability) => (
+                    <li key={ability.id}>
+                      <Chip backgroundColor={ability.color}>{ability.name}</Chip>
+                    </li>
+                  ))}
+                </ul>
               </td>
             </tr>
           ))}

--- a/frontend/src/pages/ProfilePageReports/ReportStudyLogTable.js
+++ b/frontend/src/pages/ProfilePageReports/ReportStudyLogTable.js
@@ -43,7 +43,9 @@ const ReportStudyLogTable = ({ studyLogs }) => {
                 <ul>
                   {abilities.map((ability) => (
                     <li key={ability.id}>
-                      <Chip backgroundColor={ability.color}>{ability.name}</Chip>
+                      <Chip backgroundColor={ability.color} fontSize="1.2rem">
+                        {ability.name}
+                      </Chip>
                     </li>
                   ))}
                 </ul>

--- a/frontend/src/pages/ProfilePageReports/ReportStudyLogTable.styles.js
+++ b/frontend/src/pages/ProfilePageReports/ReportStudyLogTable.styles.js
@@ -89,20 +89,26 @@ const Tbody = styled.tbody`
 
     td:nth-of-type(1) {
       height: 100%;
-      width: 6%;
+      width: 5%;
       text-align: center;
     }
 
     td:nth-of-type(2) {
+      width: 47%;
       height: 100%;
-      width: 45%;
-
-      overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap;
-      padding-right: 0.6rem;
 
       a {
+        width: 100%;
+        height: 100%;
+
+        display: block;
+
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        padding-right: 0.6rem;
+        line-height: 6rem;
+
         :hover {
           text-decoration: underline;
         }
@@ -118,7 +124,7 @@ const Tbody = styled.tbody`
       > ul {
         width: 100%;
         height: 100%;
-        margin-right: 1.5rem;
+        margin-right: 0.5rem;
         overflow: auto;
 
         display: flex;

--- a/frontend/src/pages/ProfilePageReports/ReportStudyLogTable.styles.js
+++ b/frontend/src/pages/ProfilePageReports/ReportStudyLogTable.styles.js
@@ -61,36 +61,42 @@ const Table = styled.table`
 const Thead = styled.thead`
   > tr {
     th:nth-of-type(1) {
-      width: 15%;
+      width: 10%;
       text-align: center;
     }
 
     th:nth-of-type(2) {
-      width: 85%;
+      width: 30%;
+    }
+
+    th:nth-of-type(3) {
+      width: 60%;
     }
   }
 `;
 
 const Tbody = styled.tbody`
   display: block;
-  min-height: 15rem;
+  min-height: 10rem;
 
   tr {
-    width: 98%;
+    width: 96%;
     border-bottom: 0.1rem solid ${COLOR.LIGHT_GRAY_300};
+    height: 6rem;
     margin: 0 auto;
 
-    td:nth-of-type(1) {
-      width: 12%;
-      text-align: center;
+    position: relative;
 
-      > span {
-        color: ${COLOR.BLACK_600};
-      }
+    td:nth-of-type(1) {
+      height: 100%;
+      width: 6%;
+      text-align: center;
     }
 
     td:nth-of-type(2) {
-      width: 88%;
+      height: 100%;
+      width: 45%;
+
       overflow: hidden;
       text-overflow: ellipsis;
       white-space: nowrap;
@@ -99,6 +105,27 @@ const Tbody = styled.tbody`
       a {
         :hover {
           text-decoration: underline;
+        }
+      }
+    }
+
+    td:nth-of-type(3) {
+      height: 100%;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+
+      > ul {
+        width: 100%;
+        height: 100%;
+        margin-right: 1.5rem;
+        overflow: auto;
+
+        display: flex;
+        align-items: center;
+
+        li {
+          height: fit-content;
         }
       }
     }

--- a/frontend/src/pages/ProfilePageReports/ReportStudyLogTable.styles.js
+++ b/frontend/src/pages/ProfilePageReports/ReportStudyLogTable.styles.js
@@ -99,15 +99,13 @@ const Tbody = styled.tbody`
 
       a {
         width: 100%;
-        height: 100%;
+        padding-right: 0.6rem;
 
         display: block;
 
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;
-        padding-right: 0.6rem;
-        line-height: 6rem;
 
         :hover {
           text-decoration: underline;


### PR DESCRIPTION
- [x] 리포트 학습로그 목록에 각 학습로그별 역량을 등록한다. 
related #247 

보완이 필요한 부분
- [ ] 관련 리포트 별로 정렬한다.
- [ ] 스크롤이 호버할 시에만 보인다 (현재 재 브라우저에서는 되어있는데, 다른 브라우저에서 확인 필요합니다.) 
- [ ] 역량 추가의 작은 선택화면의 디자인 논의 필요 -> 현재는 간단한 체크박스로 이루어져있음
---

디자인이 저번에 이야기 했을 때, 바뀔 수도 있다고해서 현재는 간략하게만 만들었습니다.
리포트 수정, 등록, 조회에서 모두 해당하는 학습로그의 역량을 확인할 수 있습니다.

### 현재의 로직
1. 사용자가 리포트를 생성한다.
2. 사용자는 자신의 역량을 리포트 생성 페이지에서 확인할 수 있고, 현재 리포트에서 `등록할 역량을 체크`할 수 있다.
3. 사용자는 학습로그를 `학습로그 목록`에 추가한다.
4. 학습로그에는 `2에서 선택한 역량만 선택할 수 있다.` => 현재 화면에 그려주고 있지 않음.

https://user-images.githubusercontent.com/59258239/139670770-edabb19b-7697-48b0-a4e3-61f36d1acb11.mov