### PR TITLE
fix: Phantom Dependency으로 인한 오류 해결

### DIFF
--- a/frontend/src/components/Lists/StudyLogList.tsx
+++ b/frontend/src/components/Lists/StudyLogList.tsx
@@ -1,6 +1,6 @@
 /** @jsxImportSource @emotion/react */
 import { css } from '@emotion/react';
-import { useHistory } from 'react-router';
+import { useHistory } from 'react-router-dom';
 import { Card, ProfileChip } from '..';
 import { COLOR, PATH } from '../../constants';
 import { AlignItemsEndStyle, FlexColumnStyle, FlexStyle } from '../../styles/flex.styles';

--- a/frontend/src/components/NavBar/NavBar.js
+++ b/frontend/src/components/NavBar/NavBar.js
@@ -1,8 +1,7 @@
 import PropTypes from 'prop-types';
 import { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { useHistory } from 'react-router';
-import { Link } from 'react-router-dom';
+import { useHistory, Link } from 'react-router-dom';
 import LogoImage from '../../assets/images/logo.svg';
 import { PATH } from '../../constants';
 import GithubLogin from '../GithubLogin/GithubLogin';

--- a/frontend/src/components/ProfilePageSideBar/ProfilePageSideBar.js
+++ b/frontend/src/components/ProfilePageSideBar/ProfilePageSideBar.js
@@ -1,6 +1,5 @@
 import { useState, useEffect } from 'react';
-import { useParams } from 'react-router';
-import { useHistory } from 'react-router-dom';
+import { useParams, useHistory } from 'react-router-dom';
 
 import {
   Profile,

--- a/frontend/src/pages/AbilityPage/index.js
+++ b/frontend/src/pages/AbilityPage/index.js
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
-import { useHistory, useParams } from 'react-router';
+import { useHistory, useParams } from 'react-router-dom';
 import { COLOR } from '../../constants';
 import LOCAL_STORAGE_KEY from '../../constants/localStorage';
 import {

--- a/frontend/src/pages/LoginCallbackPage/index.js
+++ b/frontend/src/pages/LoginCallbackPage/index.js
@@ -1,6 +1,6 @@
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { useHistory } from 'react-router';
+import { useHistory } from 'react-router-dom';
 
 import { login } from '../../redux/actions/userAction';
 

--- a/frontend/src/pages/MainPage/index.js
+++ b/frontend/src/pages/MainPage/index.js
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 import { Button, FilterList, Pagination } from '../../components';
-import { useHistory } from 'react-router';
+import { useHistory } from 'react-router-dom';
 import { PATH } from '../../constants';
 import PencilIcon from '../../assets/images/pencil_icon.svg';
 import useFetch from '../../hooks/useFetch';

--- a/frontend/src/pages/PostPage/index.js
+++ b/frontend/src/pages/PostPage/index.js
@@ -1,7 +1,7 @@
 /** @jsxImportSource @emotion/react */
 
 import { useEffect } from 'react';
-import { useHistory, useParams } from 'react-router';
+import { useHistory, useParams } from 'react-router-dom';
 import {
   requestGetPost,
   requestPostScrap,

--- a/frontend/src/pages/ProfilePage/index.js
+++ b/frontend/src/pages/ProfilePage/index.js
@@ -1,6 +1,5 @@
 import React, { useState, useEffect, useCallback } from 'react';
-import { useParams } from 'react-router';
-import { useHistory, useLocation } from 'react-router-dom';
+import { useParams, useHistory, useLocation } from 'react-router-dom';
 import {
   Container,
   Content,

--- a/frontend/src/pages/ProfilePageReports/index.js
+++ b/frontend/src/pages/ProfilePageReports/index.js
@@ -1,6 +1,5 @@
 import { useEffect, useState } from 'react';
-import { useHistory } from 'react-router';
-import { NavLink, useParams } from 'react-router-dom';
+import { useHistory, NavLink, useParams } from 'react-router-dom';
 import { useSelector } from 'react-redux';
 import localStorage from 'local-storage';
 


### PR DESCRIPTION
기존의 yarn의 문제점인 유령 의존성으로 인해서, `react-router-dom` 라이브러리의 API를 사용할 때 자동으로 react-router가 import 된 부분이 있어서 수정하였습니다. 