### PR TITLE
feat: elasticsearch auto healthcheck 비활성화

### DIFF
--- a/backend/src/main/resources/application-local.yml
+++ b/backend/src/main/resources/application-local.yml
@@ -30,3 +30,8 @@ github:
 elasticsearch:
   host: 127.0.0.1
   port: 9200
+
+management:
+  health:
+    elasticsearch:
+      enabled: false

--- a/backend/src/main/resources/application-test.yml
+++ b/backend/src/main/resources/application-test.yml
@@ -33,3 +33,8 @@ github:
 elasticsearch:
   host: 127.0.0.1
   port: 9200
+
+management:
+  health:
+    elasticsearch:
+      enabled: false


### PR DESCRIPTION
ref: https://stackoverflow.com/questions/48553706/elasticsearch-health-check-failed-every-time-when-spring-boot-start-up

