### PR TITLE
[역량] 스터디로그-역량 매핑 데이터를 불러오지 못하는 버그를 해결한다.

### DIFF
--- a/backend/src/main/java/wooteco/prolog/report/application/HistoryAbilityService.java
+++ b/backend/src/main/java/wooteco/prolog/report/application/HistoryAbilityService.java
@@ -11,7 +11,9 @@ import wooteco.prolog.report.application.dto.Ability2.HistoryResponse;
 import wooteco.prolog.report.application.dto.HistoryDtoAssembler;
 import wooteco.prolog.report.domain.ablity.Ability2;
 import wooteco.prolog.report.domain.ablity.History;
+import wooteco.prolog.report.domain.ablity.StudylogAbility;
 import wooteco.prolog.report.domain.ablity.repository.HistoryRepository;
+import wooteco.prolog.report.domain.report.repository.StudylogAbilityRepository;
 
 import javax.persistence.EntityManager;
 import java.util.List;
@@ -31,6 +33,7 @@ public class HistoryAbilityService {
     private final HistoryRepository historyRepository;
     private final HistoryDtoAssembler historyDtoAssembler;
     private final EntityManager entityManager;
+    private final StudylogAbilityRepository studylogAbilityRepository;
 
     public HistoryResponse readLatestHistoryByUsername(String username) {
         Member member = memberRepository.findByUsername(username)

--- a/backend/src/main/java/wooteco/prolog/report/domain/ablity/StudylogAbility.java
+++ b/backend/src/main/java/wooteco/prolog/report/domain/ablity/StudylogAbility.java
@@ -10,10 +10,12 @@ public class StudylogAbility {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "history_id")
     private History history;
 
-    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.MERGE)
+    @ManyToOne(cascade = CascadeType.MERGE)
+    @JoinColumn(name = "ability_id")
     private Ability2 ability;
 
     private Long studylogId;

--- a/backend/src/main/java/wooteco/prolog/report/domain/ablity/Studylogs.java
+++ b/backend/src/main/java/wooteco/prolog/report/domain/ablity/Studylogs.java
@@ -1,18 +1,17 @@
 package wooteco.prolog.report.domain.ablity;
 
-import javax.persistence.CascadeType;
-import javax.persistence.Embeddable;
-import javax.persistence.FetchType;
-import javax.persistence.OneToMany;
+import javax.persistence.*;
+import java.util.ArrayList;
 import java.util.List;
 
 @Embeddable
 public class Studylogs {
 
-    @OneToMany(fetch = FetchType.LAZY, cascade = CascadeType.MERGE, orphanRemoval = true)
+    @OneToMany(fetch = FetchType.LAZY, cascade = CascadeType.MERGE, orphanRemoval = true, mappedBy = "history")
     private List<StudylogAbility> values;
 
     protected Studylogs() {
+        this.values = new ArrayList<>();
     }
 
     public Studylogs(List<StudylogAbility> values) {

--- a/backend/src/main/java/wooteco/prolog/report/domain/report/repository/StudylogAbilityRepository.java
+++ b/backend/src/main/java/wooteco/prolog/report/domain/report/repository/StudylogAbilityRepository.java
@@ -1,0 +1,7 @@
+package wooteco.prolog.report.domain.report.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import wooteco.prolog.report.domain.ablity.StudylogAbility;
+
+public interface StudylogAbilityRepository extends JpaRepository<StudylogAbility, Long> {
+}


### PR DESCRIPTION
해결은 했습니다만 뚜렷한 이유는 모르겠습니다.
일단 연관관계 주인 관련된 셋팅이 잘 안돼있던 부분이 발견돼서 처리하였습니다(join_column 및 mappedBy 누락)

studylog를 불러오지 못하는(null) 버그는
<img width="353" alt="image" src="https://user-images.githubusercontent.com/33603557/150662342-07c38d04-1211-4f4d-8469-7fe15acad725.png">
기본 생성자에 ArrayList<>()를 바인딩 해서 해결했는데, 이게 왜 기본적으로 있어야 하는지 잘 이해가 안되네요..
안넣어줘도 잘 됐던것 같은데... 오묘한 JPA의 세계.... 