### PR TITLE
fix: studylog 삭제가 안되는 오류 수정

### DIFF
--- a/backend/src/main/java/wooteco/prolog/studylog/domain/repository/StudylogReadRepository.java
+++ b/backend/src/main/java/wooteco/prolog/studylog/domain/repository/StudylogReadRepository.java
@@ -4,9 +4,12 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import wooteco.prolog.studylog.domain.StudylogRead;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface StudylogReadRepository extends JpaRepository<StudylogRead, Long> {
     boolean existsByMemberIdAndStudylogId(Long memberId, Long studylogId);
+
+    Optional<StudylogRead> findByMemberIdAndStudylogId(Long memberId, Long studylogId);
 
     List<StudylogRead> findByMemberId(Long memberId);
 }

--- a/backend/src/main/java/wooteco/prolog/studylog/domain/repository/StudylogScrapRepository.java
+++ b/backend/src/main/java/wooteco/prolog/studylog/domain/repository/StudylogScrapRepository.java
@@ -13,6 +13,8 @@ public interface StudylogScrapRepository extends JpaRepository<StudylogScrap, Lo
     @Query("select count(ms) from StudylogScrap ms where ms.member.id = :memberId and ms.studylog.id = :studylogId")
     int countByMemberIdAndScrapStudylogId(Long memberId, Long studylogId);
 
+    boolean existsByMemberIdAndStudylogId(Long memberId, Long studylogId);
+
     Optional<StudylogScrap> findByMemberIdAndStudylogId(Long memberId, Long studylogId);
 
     Page<StudylogScrap> findByMemberId(Long memberId, Pageable pageable);

--- a/backend/src/main/java/wooteco/prolog/studylog/exception/StudylogReadNotExistException.java
+++ b/backend/src/main/java/wooteco/prolog/studylog/exception/StudylogReadNotExistException.java
@@ -2,7 +2,6 @@ package wooteco.prolog.studylog.exception;
 
 import wooteco.prolog.common.exception.BadRequestException;
 
-public class StudylogReadNotExistException extends
-        BadRequestException {
+public class StudylogReadNotExistException extends BadRequestException {
 
 }

--- a/backend/src/main/java/wooteco/prolog/studylog/exception/StudylogReadNotExistException.java
+++ b/backend/src/main/java/wooteco/prolog/studylog/exception/StudylogReadNotExistException.java
@@ -1,0 +1,8 @@
+package wooteco.prolog.studylog.exception;
+
+import wooteco.prolog.common.exception.BadRequestException;
+
+public class StudylogReadNotExistException extends
+        BadRequestException {
+
+}

--- a/backend/src/main/java/wooteco/prolog/studylog/exception/StudylogScrapAlreadyRegisteredException.java
+++ b/backend/src/main/java/wooteco/prolog/studylog/exception/StudylogScrapAlreadyRegisteredException.java
@@ -2,7 +2,6 @@ package wooteco.prolog.studylog.exception;
 
 import wooteco.prolog.common.exception.BadRequestException;
 
-public class StudylogScrapAlreadyRegisteredException extends
-    BadRequestException {
+public class StudylogScrapAlreadyRegisteredException extends BadRequestException {
 
 }

--- a/backend/src/main/java/wooteco/prolog/studylog/exception/StudylogScrapNotExistException.java
+++ b/backend/src/main/java/wooteco/prolog/studylog/exception/StudylogScrapNotExistException.java
@@ -2,7 +2,6 @@ package wooteco.prolog.studylog.exception;
 
 import wooteco.prolog.common.exception.BadRequestException;
 
-public class StudylogScrapNotExistException extends
-    BadRequestException {
+public class StudylogScrapNotExistException extends BadRequestException {
 
 }

--- a/backend/src/main/java/wooteco/prolog/studylog/exception/StudylogScrapNotValidUserException.java
+++ b/backend/src/main/java/wooteco/prolog/studylog/exception/StudylogScrapNotValidUserException.java
@@ -2,7 +2,6 @@ package wooteco.prolog.studylog.exception;
 
 import wooteco.prolog.common.exception.BadRequestException;
 
-public class StudylogScrapNotValidUserException extends
-    BadRequestException {
+public class StudylogScrapNotValidUserException extends BadRequestException {
 
 }


### PR DESCRIPTION
## 구현 기능
- studylog 삭제 시 해당 글에 대한 스크랩과 읽음여부도 같이 삭제되도록 수정했습니다.

Close #634 