### PR TITLE
[좋아요 버그] dev 서버 에러 발생 

### DIFF
--- a/backend/src/main/java/wooteco/prolog/studylog/domain/Like.java
+++ b/backend/src/main/java/wooteco/prolog/studylog/domain/Like.java
@@ -2,9 +2,12 @@ package wooteco.prolog.studylog.domain;
 
 import java.util.Objects;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
@@ -20,9 +23,14 @@ public class Like {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "studylog_id")
+    private Studylog studylog;
+
     private Long memberId;
 
-    public Like(Long memberId) {
+    public Like(Studylog studylog, Long memberId) {
+        this.studylog = studylog;
         this.memberId = memberId;
     }
 

--- a/backend/src/main/java/wooteco/prolog/studylog/domain/Likes.java
+++ b/backend/src/main/java/wooteco/prolog/studylog/domain/Likes.java
@@ -4,19 +4,19 @@ import java.util.ArrayList;
 import java.util.List;
 import javax.persistence.CascadeType;
 import javax.persistence.Embeddable;
-import javax.persistence.JoinColumn;
 import javax.persistence.OneToMany;
-import org.hibernate.annotations.BatchSize;
 import wooteco.prolog.studylog.exception.InvalidLikeRequestException;
 import wooteco.prolog.studylog.exception.InvalidUnlikeRequestException;
 
 @Embeddable
 public class Likes {
 
-    @OneToMany(cascade = CascadeType.PERSIST, orphanRemoval = true)
-    @JoinColumn(name = "studylog_id")
-    @BatchSize(size = 1000)
-    private final List<Like> values;
+    @OneToMany(
+        cascade = {CascadeType.PERSIST, CascadeType.REMOVE},
+        orphanRemoval = true,
+        mappedBy = "studylog"
+    )
+    private List<Like> values;
 
     public Likes() {
         this(new ArrayList<>());
@@ -30,9 +30,9 @@ public class Likes {
         return values;
     }
 
-    public void like(Long id) {
-        validateNewLike(id);
-        values.add(new Like(id));
+    public void like(Studylog studylog, Long memberId) {
+        validateNewLike(memberId);
+        values.add(new Like(studylog, memberId));
     }
 
     private void validateNewLike(Long id) {
@@ -45,9 +45,9 @@ public class Likes {
             });
     }
 
-    public void unlike(Long id) {
-        validateExistingLike(id);
-        values.remove(new Like(id));
+    public void unlike(Studylog studylog, Long memberId) {
+        validateExistingLike(memberId);
+        values.remove(new Like(studylog, memberId));
     }
 
     private void validateExistingLike(Long id) {

--- a/backend/src/main/java/wooteco/prolog/studylog/domain/Studylog.java
+++ b/backend/src/main/java/wooteco/prolog/studylog/domain/Studylog.java
@@ -106,11 +106,11 @@ public class Studylog extends BaseEntity {
     }
 
     public void like(Long id) {
-        likes.like(id);
+        likes.like(this, id);
     }
 
     public void unlike(Long id) {
-        likes.unlike(id);
+        likes.unlike(this, id);
     }
 
     public boolean likedByMember(Long memberId) {

--- a/backend/src/main/java/wooteco/prolog/studylog/ui/StudylogLikeController.java
+++ b/backend/src/main/java/wooteco/prolog/studylog/ui/StudylogLikeController.java
@@ -21,7 +21,7 @@ public class StudylogLikeController {
         this.studylogLikeService = studylogLikeService;
     }
 
-    @PostMapping("{studylogId}/likes")
+    @PostMapping("/{studylogId}/likes")
     public ResponseEntity<StudylogLikeResponse> likeStudylog(
         @AuthMemberPrincipal LoginMember member,
         @PathVariable Long studylogId
@@ -31,7 +31,7 @@ public class StudylogLikeController {
         return ResponseEntity.ok(studylogLikeResponse);
     }
 
-    @DeleteMapping("{studylogId}/likes")
+    @DeleteMapping("/{studylogId}/likes")
     public ResponseEntity<StudylogLikeResponse> unlikeStudylog(
         @AuthMemberPrincipal LoginMember member,
         @PathVariable Long studylogId


### PR DESCRIPTION
에러로그는 JPA 롤백이지만 자세한 trace를 확인할 수 없어 우선 발견한 버그 가능 지점만 수정합니다.

### 수정 부분 
- StudylogLikeController 에 uri path 에 `/` 누락된 부분
- 발생하고 있는 에러  `Could not commit JPA transaction; nested exception is javax.persistence.RollbackException: Error while committing the transaction` 
   - 정확히 왜 이런 에러가 발생하는지 디버깅을 할 수 없고 stack trace가 남지 않는 관계로 유추할 수밖에 없는 상황인데요 ㅠㅠ 
   - 에러가 발생할 수 있는 예상 지점은 1) Flyway 혹은 2) 알 수 없는 JPA 연관관계 문제 라고 생각합니다. 
   - 1)번 같은 경우에는 ddl-auto 설정이  validate 이므로 문제가 될 여지가 적다고 생각
   - **2)번은 현재 일대다 단방향 연관관계를 사용하고 있었으나 매우 비추하는 연관관계이므로 다대일 양방향으로 수정**
- 문제가 된 부분은 아니라고 생각하지만 entity의 필드는 final이 아닌것이 원칙이므로 Likes 내부 values 컬렉션에 final을 제거 


resolve #684