### PR TITLE
fix: 로그인 상태 이상을 해결한다.

### DIFF
--- a/frontend/src/contexts/UserProvider.js
+++ b/frontend/src/contexts/UserProvider.js
@@ -1,4 +1,4 @@
-import { createContext, useState } from 'react';
+import { createContext, useState, useEffect } from 'react';
 
 import LOCAL_STORAGE_KEY from '../constants/localStorage';
 import useMutation from '../hooks/useMutation';
@@ -50,6 +50,7 @@ const UserProvider = ({ children }) => {
   const { mutate: onLogin } = useMutation(loginRequest, {
     onSuccess: ({ accessToken }) => {
       localStorage.setItem(LOCAL_STORAGE_KEY.ACCESS_TOKEN, JSON.stringify(accessToken));
+      setState((prev) => ({ ...prev, accessToken }));
     },
   });
 
@@ -58,13 +59,17 @@ const UserProvider = ({ children }) => {
     setState(DEFAULT_USER);
   };
 
-  useState(() => {
+  useEffect(() => {
     const accessToken = getLocalStorageItem(LOCAL_STORAGE_KEY.ACCESS_TOKEN);
 
     if (accessToken) {
       setState({ ...state, accessToken });
     }
   }, []);
+
+  useEffect(() => {
+    userProfileRequest.fetchData();
+  }, [state.accessToken]);
 
   return (
     <UserContext.Provider value={{ user: state, onLogin, onLogout }}>

--- a/frontend/src/contexts/UserProvider.js
+++ b/frontend/src/contexts/UserProvider.js
@@ -23,7 +23,13 @@ const UserProvider = ({ children }) => {
 
   const userProfileRequest = useRequest(
     DEFAULT_USER,
-    () => getUserProfileRequest({ accessToken: state.accessToken }),
+    () => {
+      if (!state.accessToken) {
+        return;
+      }
+
+      return getUserProfileRequest({ accessToken: state.accessToken });
+    },
     ({ id: userId, username, nickname, role, imageUrl }) => {
       setState((prev) => ({
         ...prev,

--- a/frontend/src/pages/LoginCallbackPage/index.js
+++ b/frontend/src/pages/LoginCallbackPage/index.js
@@ -1,5 +1,6 @@
 import { useContext, useEffect } from 'react';
 import { useHistory } from 'react-router-dom';
+import { PATH } from '../../constants';
 
 import { UserContext } from '../../contexts/UserProvider';
 
@@ -14,7 +15,8 @@ const LoginCallbackPage = () => {
   useEffect(() => {
     const login = async () => {
       await onLogin({ code });
-      history.goBack();
+      // history.goBack()을 이용하는 경우 로그인 허용 페이지로 돌아갈 가능성 있음.
+      history.push(PATH.ROOT);
     };
 
     if (code) {
@@ -24,7 +26,7 @@ const LoginCallbackPage = () => {
 
   useEffect(() => {
     if (isLoggedIn) {
-      history.goBack();
+      history.push(PATH.ROOT);
 
       return;
     }


### PR DESCRIPTION
*   로그인 성공 시 상태 업데이트를 하고 있지 않은 이슈 수정
*   accessToken 변경시 Members/me 재 요청 보내도록 수정
*   accessToken 값이 Null 일 시 members/me 요청을 보내지 않도록 수정
*   깃허브에 직접 Id, pw 를 입력하는 경우 history.goBack() 을 이용하면 이전 조회하던 페이지가 유지되지 않는 이슈로, 로그인 성공시 무조건 메인화면으로 가도록 수정