### PR TITLE
hotfix(FE): 학습로그 삭제시 라우트 및 성공 메세지가 노출되지 않는 이슈 해결

### DIFF
--- a/frontend/src/constants/message.js
+++ b/frontend/src/constants/message.js
@@ -42,6 +42,7 @@ const ERROR_MESSAGE = {
 
 const SUCCESS_MESSAGE = {
   CREATE_POST: '글이 작성되었습니다.',
+  DELETE_STUDYLOG: '글이 삭제되었습니다.',
   CREATE_ABILITY: '역량을 추가했습니다.',
   EDIT_ABILITY: '역량을 수정했습니다.',
   DELETE_ABILITY: '역량을 삭제했습니다.',

--- a/frontend/src/pages/StudylogPage/index.js
+++ b/frontend/src/pages/StudylogPage/index.js
@@ -49,6 +49,9 @@ const StudylogPage = () => {
       return requestDeleteStudylog({ id, accessToken });
     },
     {
+      onSuccess: () => {
+        history.push(PATH.STUDYLOG);
+      },
       onError: (error) => {
         alert(ERROR_MESSAGE[error.code] ?? ALERT_MESSAGE.FAIL_TO_DELETE_STUDYLOG);
       },

--- a/frontend/src/pages/StudylogPage/index.js
+++ b/frontend/src/pages/StudylogPage/index.js
@@ -29,6 +29,7 @@ import {
   PATH,
   SNACKBAR_MESSAGE,
 } from '../../constants';
+import { SUCCESS_MESSAGE } from '../../constants/message';
 
 const StudylogPage = () => {
   const { id } = useParams();
@@ -50,6 +51,7 @@ const StudylogPage = () => {
     },
     {
       onSuccess: () => {
+        openSnackBar(SUCCESS_MESSAGE.DELETE_STUDYLOG);
         history.push(PATH.STUDYLOG);
       },
       onError: (error) => {


### PR DESCRIPTION
* 학습로그 삭제 시 학습로그 페이지로 라우팅
* 학습로그 삭제 완료 시 안내메세지 노출
* 그 외 이슈는 백엔드 확인 필요함