### PR TITLE
hotfix: 로그인 세션이 만료되었을때 홈화면에 글 리스트가 나오지 않는 이슈 수정

### DIFF
--- a/frontend/src/hooks/useStudylog.js
+++ b/frontend/src/hooks/useStudylog.js
@@ -19,6 +19,7 @@ const useStudylog = (defaultValue) => {
 
   const onSuccess = (data) => {
     setResponse(data);
+    setError('');
   };
 
   const onError = (error) => {

--- a/frontend/src/hooks/useStudylog.js
+++ b/frontend/src/hooks/useStudylog.js
@@ -10,7 +10,9 @@ import useMutation from './useMutation';
 
 const useStudylog = (defaultValue) => {
   const [response, setResponse] = useState(defaultValue);
+  // TODO: errorObj로 통일, 현재는 해당 메시지를 다른곳에서 이용하고 있어 별도로 생성함.
   const [error, setError] = useState('');
+  const [errorObj, setErrorObj] = useState({});
 
   const onSuccess = (data) => {
     setResponse(data);
@@ -18,7 +20,9 @@ const useStudylog = (defaultValue) => {
 
   const onError = (error) => {
     console.error(error);
+
     setError(ERROR_MESSAGE[error.code] ?? ERROR_MESSAGE.DEFAULT);
+    setErrorObj({ code: error.code, message: ERROR_MESSAGE[error.code] ?? ERROR_MESSAGE.DEFAULT })
   };
 
   const { mutate: getAllData } = useMutation(requestGetStudylogs, {
@@ -47,7 +51,7 @@ const useStudylog = (defaultValue) => {
 
   const { mutate: deleteData } = useMutation(requestDeleteStudylog, { onSuccess, onError });
 
-  return { response, error, getAllData, getData, editData, deleteData };
+  return { response, error, errorObj, getAllData, getData, editData, deleteData };
 };
 
 export default useStudylog;

--- a/frontend/src/hooks/useStudylog.js
+++ b/frontend/src/hooks/useStudylog.js
@@ -1,4 +1,6 @@
-import { useState } from 'react';
+import { useContext, useState } from 'react';
+
+import { UserContext } from '../contexts/UserProvider';
 import { ERROR_MESSAGE } from '../constants/message';
 import {
   requestGetStudylog,
@@ -7,12 +9,13 @@ import {
   requestEditStudylog,
 } from '../service/requests';
 import useMutation from './useMutation';
+import ERROR_CODE from '../constants/errorCode';
 
 const useStudylog = (defaultValue) => {
   const [response, setResponse] = useState(defaultValue);
-  // TODO: errorObj로 통일, 현재는 해당 메시지를 다른곳에서 이용하고 있어 별도로 생성함.
   const [error, setError] = useState('');
-  const [errorObj, setErrorObj] = useState({});
+
+  const { onLogout } = useContext(UserContext)
 
   const onSuccess = (data) => {
     setResponse(data);
@@ -21,8 +24,11 @@ const useStudylog = (defaultValue) => {
   const onError = (error) => {
     console.error(error);
 
+    if (error.code === ERROR_CODE.EXPIRED_ACCESS_TOKEN) {
+      onLogout();
+    }
+
     setError(ERROR_MESSAGE[error.code] ?? ERROR_MESSAGE.DEFAULT);
-    setErrorObj({ code: error.code, message: ERROR_MESSAGE[error.code] ?? ERROR_MESSAGE.DEFAULT })
   };
 
   const { mutate: getAllData } = useMutation(requestGetStudylogs, {
@@ -51,7 +57,7 @@ const useStudylog = (defaultValue) => {
 
   const { mutate: deleteData } = useMutation(requestDeleteStudylog, { onSuccess, onError });
 
-  return { response, error, errorObj, getAllData, getData, editData, deleteData };
+  return { response, error, getAllData, getData, editData, deleteData };
 };
 
 export default useStudylog;

--- a/frontend/src/pages/MainPage/index.js
+++ b/frontend/src/pages/MainPage/index.js
@@ -5,7 +5,6 @@ import useStudylog from '../../hooks/useStudylog';
 
 import BannerList from '../../components/Banner/BannerList';
 import RecentStudylogList from './RecentStudylogList';
-import ERROR_CODE from '../../constants/errorCode';
 
 import { MainContentStyle } from '../../PageRouter';
 
@@ -13,23 +12,13 @@ import bannerList from '../../configs/bannerList';
 import { UserContext } from '../../contexts/UserProvider';
 
 const MainPage = () => {
-  const { user, onLogout } = useContext(UserContext);
+  const { user } = useContext(UserContext);
   const { accessToken } = user;
-  const { response: recentStudylogs, errorObj: recentStudylogsError, getAllData: fetchRecentStudylogs } = useStudylog([]);
+  const { response: recentStudylogs, getAllData: fetchRecentStudylogs } = useStudylog([]);
 
   useEffect(() => {
     fetchRecentStudylogs({ query: { type: 'searchParams', data: 'size=3' }, accessToken });
   }, [accessToken]);
-
-  // 임시 방편으로 EXPIRED_ACCESS_TOKEN에러 시 토큰 초기화 시행
-  // TODO: Unauthorize Error 공통 대응 필요.
-  useEffect(() => {
-    if (recentStudylogsError.code === ERROR_CODE.EXPIRED_ACCESS_TOKEN) {
-      // 토큰 초기화
-      onLogout();
-    }
-  }, [recentStudylogsError])
-
 
   return (
     <>

--- a/frontend/src/pages/MainPage/index.js
+++ b/frontend/src/pages/MainPage/index.js
@@ -5,6 +5,7 @@ import useStudylog from '../../hooks/useStudylog';
 
 import BannerList from '../../components/Banner/BannerList';
 import RecentStudylogList from './RecentStudylogList';
+import ERROR_CODE from '../../constants/errorCode';
 
 import { MainContentStyle } from '../../PageRouter';
 
@@ -12,13 +13,23 @@ import bannerList from '../../configs/bannerList';
 import { UserContext } from '../../contexts/UserProvider';
 
 const MainPage = () => {
-  const { user } = useContext(UserContext);
+  const { user, onLogout } = useContext(UserContext);
   const { accessToken } = user;
-  const { response: recentStudylogs, getAllData: fetchRecentStudylogs } = useStudylog([]);
+  const { response: recentStudylogs, errorObj: recentStudylogsError, getAllData: fetchRecentStudylogs } = useStudylog([]);
 
   useEffect(() => {
     fetchRecentStudylogs({ query: { type: 'searchParams', data: 'size=3' }, accessToken });
   }, [accessToken]);
+
+  // 임시 방편으로 EXPIRED_ACCESS_TOKEN에러 시 토큰 초기화 시행
+  // TODO: Unauthorize Error 공통 대응 필요.
+  useEffect(() => {
+    if (recentStudylogsError.code === ERROR_CODE.EXPIRED_ACCESS_TOKEN) {
+      // 토큰 초기화
+      onLogout();
+    }
+  }, [recentStudylogsError])
+
 
   return (
     <>

--- a/frontend/src/pages/MainPage/index.js
+++ b/frontend/src/pages/MainPage/index.js
@@ -14,11 +14,17 @@ import { UserContext } from '../../contexts/UserProvider';
 const MainPage = () => {
   const { user } = useContext(UserContext);
   const { accessToken } = user;
-  const { response: recentStudylogs, getAllData: fetchRecentStudylogs } = useStudylog([]);
+  const { response: recentStudylogs, error: recentStudylogsError, getAllData: fetchRecentStudylogs } = useStudylog([]);
 
   useEffect(() => {
     fetchRecentStudylogs({ query: { type: 'searchParams', data: 'size=3' }, accessToken });
   }, [accessToken]);
+
+  useEffect(() => {
+    if (recentStudylogsError) {
+      alert(recentStudylogsError)
+    }
+  }, [recentStudylogsError])
 
   return (
     <>


### PR DESCRIPTION
fixed #712 

해당 이슈 글 불러오기 시 unauthorization Error 에 대한 추가 대응이 없어 발생한 이슈로, 추후 공통된 에러 처리 로직 추가(#713)가 필요합니다.

로컬에서 재현시 store에 저장된 값을 임의로 유효하지 않은 값으로 만들기 위해
MainPage 코드 의 다음 코드를 아래와 같이 수정하여 임의로 확인 가능합니다.
```
  useEffect(() => {
    fetchRecentStudylogs({ query: { type: 'searchParams', data: 'size=3' }, accessToken });
  }, [accessToken]);

```
```
  useEffect(() => {
    fetchRecentStudylogs({ query: { type: 'searchParams', data: 'size=3' }, accessToken: accessToken ? accessToken + '1' : accessToken});
  }, [accessToken]);
```
