### PR TITLE
hotfix: 내 학습로그 페이지에서 학습로그를 삭제하면 로그인이 풀리는 오류 해결

### DIFF
--- a/frontend/src/pages/ProfilePageStudylogs/index.js
+++ b/frontend/src/pages/ProfilePageStudylogs/index.js
@@ -89,7 +89,7 @@ const ProfilePageStudylogs = () => {
 
     if (!window.confirm(CONFIRM_MESSAGE.DELETE_STUDYLOG)) return;
 
-    await deletePost(id, accessToken);
+    await deletePost({ id, accessToken });
 
     if (postError) {
       alert(ALERT_MESSAGE.FAIL_TO_DELETE_STUDYLOG);


### PR DESCRIPTION
resolved #731 

설명은 이슈에 써놓아서 생략하겠습니다!
객체형식으로 넘겨주는 코드만 추가하였습니다.