### PR TITLE
fix: userContext의 DEFAULT_USER 수정 및 불필요한 useEffect 삭제

### DIFF
--- a/frontend/src/contexts/UserProvider.js
+++ b/frontend/src/contexts/UserProvider.js
@@ -12,7 +12,7 @@ const DEFAULT_USER = {
   nickname: null,
   role: null,
   imageUrl: null,
-  accessToken: null,
+  accessToken: getLocalStorageItem(LOCAL_STORAGE_KEY.ACCESS_TOKEN),
   isLoggedIn: false,
 };
 
@@ -20,6 +20,10 @@ export const UserContext = createContext(DEFAULT_USER);
 
 const UserProvider = ({ children }) => {
   const [state, setState] = useState(DEFAULT_USER);
+
+  useEffect(() => {
+    userProfileRequest.fetchData();
+  }, [state.accessToken]);
 
   const userProfileRequest = useRequest(
     DEFAULT_USER,
@@ -58,18 +62,6 @@ const UserProvider = ({ children }) => {
     localStorage.removeItem(LOCAL_STORAGE_KEY.ACCESS_TOKEN);
     setState(DEFAULT_USER);
   };
-
-  useEffect(() => {
-    const accessToken = getLocalStorageItem(LOCAL_STORAGE_KEY.ACCESS_TOKEN);
-
-    if (accessToken) {
-      setState({ ...state, accessToken });
-    }
-  }, []);
-
-  useEffect(() => {
-    userProfileRequest.fetchData();
-  }, [state.accessToken]);
 
   return (
     <UserContext.Provider value={{ user: state, onLogin, onLogout }}>

--- a/frontend/src/contexts/UserProvider.js
+++ b/frontend/src/contexts/UserProvider.js
@@ -12,21 +12,24 @@ const DEFAULT_USER = {
   nickname: null,
   role: null,
   imageUrl: null,
-  accessToken: getLocalStorageItem(LOCAL_STORAGE_KEY.ACCESS_TOKEN),
+  accessToken: null,
   isLoggedIn: false,
 };
 
 export const UserContext = createContext(DEFAULT_USER);
 
 const UserProvider = ({ children }) => {
-  const [state, setState] = useState(DEFAULT_USER);
+  const [state, setState] = useState({
+    ...DEFAULT_USER,
+    accessToken: getLocalStorageItem(LOCAL_STORAGE_KEY.ACCESS_TOKEN),
+  });
 
   useEffect(() => {
     userProfileRequest.fetchData();
   }, [state.accessToken]);
 
   const userProfileRequest = useRequest(
-    DEFAULT_USER,
+    state,
     () => {
       if (!state.accessToken) {
         return;
@@ -45,10 +48,7 @@ const UserProvider = ({ children }) => {
         isLoggedIn: true,
       }));
     },
-    () => {
-      localStorage.removeItem(LOCAL_STORAGE_KEY.ACCESS_TOKEN);
-      setState(DEFAULT_USER);
-    }
+    onLogout
   );
 
   const { mutate: onLogin } = useMutation(loginRequest, {
@@ -58,10 +58,10 @@ const UserProvider = ({ children }) => {
     },
   });
 
-  const onLogout = () => {
+  function onLogout() {
     localStorage.removeItem(LOCAL_STORAGE_KEY.ACCESS_TOKEN);
     setState(DEFAULT_USER);
-  };
+  }
 
   return (
     <UserContext.Provider value={{ user: state, onLogin, onLogout }}>


### PR DESCRIPTION
resolve #744 

### 설명
* 오류에 대한 설명은 이슈에 설명되어 있으므로 생략
* 코드 수정
  * localStorage에 저장되어있는 accessToken을 가져오는 것이 utils 함수로 어디에서나 사용할 수 있기 때문에 바로 default 값에 넣어도 될 것이라고 생각합니다. 어차피 그때 값이 없다면 null이 리턴되므로 기존에 있었던 코드의 기존값과 같아집니다. 또한, 처음 렌더시 state에 초기값을 넣는데 또 useEffect로 accessToken에 대한 상태값을 바꿔주는 것이 useState의 default value를 넣어주는 것과 동일한 작업을 두번 반복한다는 생각이 들어서 삭제하였습니다. 


### 기타
* 문제 발생이 역량 페이지처럼 특수한 페이지 내에서만 나는 걸로 봐서, 다음 배포때 나가도 될 것 같은데 
만약 다른 페이지에서 비슷한 문제가 있다면 핫픽스로 나가야할 것 같습니다. 일단 버그로 올리겠습니다.
