### PR TITLE
[API 문서 개선] 최신화

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -129,9 +129,9 @@ task createDocument(type: Copy) {
     into file("src/main/resources/static")
 }
 
-//bootJar {
-//    dependsOn createDocument
-//}
+bootJar {
+    dependsOn createDocument
+}
 
 task acceptanceTest(type: Test) {
     testClassesDirs = sourceSets.acceptanceTest.output.classesDirs

--- a/backend/src/documentation/adoc/ability.adoc
+++ b/backend/src/documentation/adoc/ability.adoc
@@ -141,16 +141,6 @@ include::{snippets}/abilities/delete/http-request.adoc[]
 
 include::{snippets}/abilities/delete/http-response.adoc[]
 
-=== 역량 제거 - 하위 역량 존재시 예외 발생
-
-==== Request
-
-include::{snippets}/abilities/delete-has-children-exception/http-request.adoc[]
-
-==== Response
-
-include::{snippets}/abilities/delete-has-children-exception/http-response.adoc[]
-
 === 기본 역량 등록 - 백엔드
 
 ==== Request

--- a/backend/src/documentation/adoc/index.adoc
+++ b/backend/src/documentation/adoc/index.adoc
@@ -7,8 +7,9 @@
 :sectlinks:
 
 include::login.adoc[]
-include::studylog.adoc[]
 include::profile.adoc[]
+include::level.adoc[]
+include::studylog.adoc[]
 include::mission.adoc[]
 include::tag.adoc[]
 include::filter.adoc[]

--- a/backend/src/documentation/adoc/level.adoc
+++ b/backend/src/documentation/adoc/level.adoc
@@ -1,0 +1,18 @@
+[[level]]
+== 레벨
+
+=== 레벨 등록
+
+==== Request
+include::{snippets}/levels/create/http-request.adoc[]
+
+==== Response
+include::{snippets}/levels/create/http-response.adoc[]
+
+=== 레벨 목록 조회
+
+==== Request
+include::{snippets}/levels/list/http-request.adoc[]
+
+==== Response
+include::{snippets}/levels/list/http-response.adoc[]

--- a/backend/src/documentation/adoc/login.adoc
+++ b/backend/src/documentation/adoc/login.adoc
@@ -11,6 +11,16 @@ include::{snippets}/login/token/http-request.adoc[]
 
 include::{snippets}/login/token/http-response.adoc[]
 
+=== 본인 정보 요청
+
+==== Request
+
+include::{snippets}/members/me/http-request.adoc[]
+
+==== Response
+
+include::{snippets}/members/me/http-response.adoc[]
+
 === 멤버 정보 요청
 
 ==== Request

--- a/backend/src/documentation/adoc/profile.adoc
+++ b/backend/src/documentation/adoc/profile.adoc
@@ -11,6 +11,26 @@ include::{snippets}/profile/profile/http-request.adoc[]
 
 include::{snippets}/profile/profile/http-response.adoc[]
 
+=== 프로필 소개 조회
+
+==== Request
+
+include::{snippets}/profile/profile-intro/http-request.adoc[]
+
+==== Response
+
+include::{snippets}/profile/profile-intro/http-response.adoc[]
+
+=== 프로필 소개 수정
+
+==== Request
+
+include::{snippets}/profile/update-profile-intro/http-request.adoc[]
+
+==== Response
+
+include::{snippets}/profile/update-profile-intro/http-response.adoc[]
+
 === 프로필 스터디로그 조회
 
 ==== Request

--- a/backend/src/documentation/adoc/reaction.adoc
+++ b/backend/src/documentation/adoc/reaction.adoc
@@ -30,3 +30,23 @@ include::{snippets}/members/scrap/list/http-request.adoc[]
 ==== Response
 
 include::{snippets}/members/scrap/list/http-response.adoc[]
+
+=== 사용자 스터디로그 좋아요
+
+==== Request
+
+include::{snippets}/studylog/like/http-request.adoc[]
+
+==== Response
+
+include::{snippets}/studylog/like/http-response.adoc[]
+
+=== 사용자 스터디로그 좋아요 취소
+
+==== Request
+
+include::{snippets}/studylog/unlike/http-request.adoc[]
+
+==== Response
+
+include::{snippets}/studylog/unlike/http-response.adoc[]

--- a/backend/src/documentation/adoc/studylog.adoc
+++ b/backend/src/documentation/adoc/studylog.adoc
@@ -21,15 +21,15 @@ include::{snippets}/studylog/list/http-request.adoc[]
 
 include::{snippets}/studylog/list/http-response.adoc[]
 
-=== 스터디로그 검색
-
-==== Request
-
-include::{snippets}/studylog/filter/http-request.adoc[]
-
-==== Response
-
-include::{snippets}/studylog/filter/http-response.adoc[]
+//=== 스터디로그 검색
+//
+//==== Request
+//
+//include::{snippets}/studylog/filter/http-request.adoc[]
+//
+//==== Response
+//
+//include::{snippets}/studylog/filter/http-response.adoc[]
 
 === 스터디로그 단건 조회
 

--- a/backend/src/documentation/adoc/studylogOverview.adoc
+++ b/backend/src/documentation/adoc/studylogOverview.adoc
@@ -20,3 +20,13 @@ include::{snippets}/members/calendar-studylogs/http-request.adoc[]
 ==== Response
 
 include::{snippets}/members/calendar-studylogs/http-response.adoc[]
+
+=== 인기있는 스터디로그 조회
+
+==== Request
+
+include::{snippets}/studylogs/most-popular/http-request.adoc[]
+
+==== Response
+
+include::{snippets}/studylogs/most-popular/http-response.adoc[]

--- a/backend/src/documentation/java/wooteco/prolog/docu/LevelDocumentation.java
+++ b/backend/src/documentation/java/wooteco/prolog/docu/LevelDocumentation.java
@@ -1,0 +1,53 @@
+package wooteco.prolog.docu;
+
+import io.restassured.RestAssured;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import wooteco.prolog.Documentation;
+import wooteco.prolog.session.application.dto.LevelRequest;
+
+public class LevelDocumentation extends Documentation {
+
+    @Test
+    void 새로운_레벨을_추가한다() {
+        LevelRequest levelRequest = new LevelRequest("새로운 레벨");
+
+        given("levels/create")
+            .header("Authorization", "Bearer " + 로그인_사용자.getAccessToken())
+            .body(levelRequest)
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .when()
+            .post("/levels")
+            .then().log().all();
+    }
+
+    @Test
+    void 레벨_목록을_조회한다() {
+        List<LevelRequest> levels = Arrays
+            .asList(new LevelRequest("새로운 레벨1"), new LevelRequest("새로운 레벨2"),
+                new LevelRequest("새로운 레벨3"));
+
+        for (LevelRequest level : levels) {
+            레벨_등록함(level);
+        }
+
+        given("levels/list")
+            .header("Authorization", "Bearer " + 로그인_사용자.getAccessToken())
+            .when()
+            .get("/levels")
+            .then().log().all();
+    }
+
+    private void 레벨_등록함(LevelRequest request) {
+        RestAssured
+            .given().log().all()
+            .body(request)
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .when()
+            .post("/levels")
+            .then().log().all()
+            .extract();
+    }
+}

--- a/backend/src/documentation/java/wooteco/prolog/docu/MemberDocumentation.java
+++ b/backend/src/documentation/java/wooteco/prolog/docu/MemberDocumentation.java
@@ -27,6 +27,15 @@ import wooteco.prolog.studylog.application.dto.TagRequest;
 public class MemberDocumentation extends Documentation {
 
     @Test
+    void 사용자_본인_정보를_조회한다() {
+        given("members/me")
+            .header("Authorization", "Bearer " + 로그인_사용자.getAccessToken())
+            .when().get("/members/me")
+            .then().log().all()
+            .extract();
+    }
+
+    @Test
     void 자신의_사용자_정보를_수정한다() {
         MemberUpdateRequest memberUpdateRequest = new MemberUpdateRequest(
             "다른이름",
@@ -87,10 +96,8 @@ public class MemberDocumentation extends Documentation {
         //when & then
         given("members/scrap/delete")
             .header("Authorization", "Bearer " + 로그인_사용자.getAccessToken())
-            .contentType(MediaType.APPLICATION_JSON_VALUE)
-            .body(new MemberScrapRequest(logId))
             .when()
-            .delete("/members/{nickname}/scrap", GithubResponses.소롱.getLogin())
+            .delete("/members/{nickname}/scrap?studylog="+ logId, GithubResponses.소롱.getLogin())
             .then().log().all()
             .assertThat()
             .statusCode(equalTo(HttpStatus.NO_CONTENT.value()));

--- a/backend/src/documentation/java/wooteco/prolog/docu/ProfileDocumentation.java
+++ b/backend/src/documentation/java/wooteco/prolog/docu/ProfileDocumentation.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
 import wooteco.prolog.Documentation;
 import wooteco.prolog.GithubResponses;
+import wooteco.prolog.member.application.dto.ProfileIntroRequest;
 import wooteco.prolog.session.application.dto.LevelRequest;
 import wooteco.prolog.session.application.dto.LevelResponse;
 import wooteco.prolog.session.application.dto.MissionRequest;
@@ -25,13 +26,33 @@ public class ProfileDocumentation extends Documentation {
 
         given("profile/studylog")
             .accept(MediaType.APPLICATION_JSON_VALUE)
-            .when().get("/members/{username}/posts", GithubResponses.소롱.getLogin());
+            .when().get("/members/{username}/studylogs", GithubResponses.소롱.getLogin());
     }
 
     @Test
     void 사용자_프로필을_조회한다() {
         given("profile/profile")
             .when().get("/members/{username}/profile", GithubResponses.소롱.getLogin())
+            .then().log().all()
+            .extract();
+    }
+
+    @Test
+    void 사용자_소개글을_조회한다() {
+        given("profile/profile-intro")
+            .when().get("/members/{username}/profile-intro", GithubResponses.소롱.getLogin())
+            .then().log().all()
+            .extract();
+    }
+
+    @Test
+    void 사용자가_본인의_소개글을_수정한다() {
+        ProfileIntroRequest request = new ProfileIntroRequest("수정된 소개글 입니다.");
+        given("profile/update-profile-intro")
+            .header("Authorization", "Bearer " + 로그인_사용자.getAccessToken())
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .body(request)
+            .when().put("/members/{username}/profile-intro", GithubResponses.소롱.getLogin())
             .then().log().all()
             .extract();
     }

--- a/backend/src/documentation/java/wooteco/prolog/docu/StudylogDocumentation.java
+++ b/backend/src/documentation/java/wooteco/prolog/docu/StudylogDocumentation.java
@@ -158,13 +158,38 @@ class StudylogDocumentation extends Documentation {
 
     @Test
     void 스터디로그를_삭제한다() {
-        ExtractableResponse<Response> studylogResponse = 스터디로그_등록함(Arrays.asList(createStudylogRequest1()));
+        ExtractableResponse<Response> studylogResponse = 스터디로그_등록함(
+            Arrays.asList(createStudylogRequest1()));
         String location = studylogResponse.header("Location");
 
         given("studylog/delete")
             .header("Authorization", "Bearer " + 로그인_사용자.getAccessToken())
             .accept(MediaType.APPLICATION_JSON_VALUE)
             .when().delete(location);
+    }
+
+    @Test
+    void 스터지로그를_좋아요한다() {
+        ExtractableResponse<Response> response = 스터디로그_등록함(Collections.singletonList(createStudylogRequest1()));
+        long studylogId = Long.parseLong(response.header("Location").split("/studylogs/")[1]);
+
+        given("studylog/like")
+            .header("Authorization", "Bearer " + 로그인_사용자.getAccessToken())
+            .when().post("/studylogs/" + studylogId + "/likes")
+            .then().log().all();
+    }
+
+    @Test
+    void 스터지로그를_좋아요_취소한다() {
+        ExtractableResponse<Response> response = 스터디로그_등록함(Collections.singletonList(createStudylogRequest1()));
+        long studylogId = Long.parseLong(response.header("Location").split("/studylogs/")[1]);
+
+        스터디로그_단건_좋아요(studylogId);
+
+        given("studylog/unlike")
+            .header("Authorization", "Bearer " + 로그인_사용자.getAccessToken())
+            .when().delete("/studylogs/" + studylogId + "/likes")
+            .then().log().all();
     }
 
     private StudylogRequest createStudylogRequest1() {
@@ -225,14 +250,14 @@ class StudylogDocumentation extends Documentation {
     }
 
     private void 스터디로그_단건_좋아요(Long studylogId) {
-        given("studylog/like")
+        RestAssured.given()
             .header("Authorization", "Bearer " + 로그인_사용자.getAccessToken())
             .when().post("/studylogs/" + studylogId + "/likes")
             .then().log().all().extract();
     }
 
     private void 스터디로그_단건_조회(Long studylogId) {
-        given("studylog/read")
+        RestAssured.given()
             .header("Authorization", "Bearer " + 로그인_사용자.getAccessToken())
             .when().get("/studylogs/" + studylogId)
             .then().log().all().extract();

--- a/backend/src/documentation/java/wooteco/prolog/docu/StudylogOverviewDocumentation.java
+++ b/backend/src/documentation/java/wooteco/prolog/docu/StudylogOverviewDocumentation.java
@@ -18,7 +18,7 @@ public class StudylogOverviewDocumentation extends Documentation {
 
     @Test
     void 유저의_달력_스터디로그를_조회한다() {
-        given("members/calendar-posts")
+        given("members/calendar-studylogs")
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .when().get("/members/{username}/calendar-stydylogs?year=2021&month=8", GithubResponses.브라운.getLogin())
                 .then().log().all()

--- a/backend/src/main/java/wooteco/prolog/studylog/ui/ProfileStudylogController.java
+++ b/backend/src/main/java/wooteco/prolog/studylog/ui/ProfileStudylogController.java
@@ -84,7 +84,7 @@ public class ProfileStudylogController {
     }
 
     @PutMapping(value = "/{username}/profile-intro", produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<ProfileIntroResponse> findMemberProfileIntro(@AuthMemberPrincipal LoginMember member, @PathVariable String username,
+    public ResponseEntity<Void> findMemberProfileIntro(@AuthMemberPrincipal LoginMember member, @PathVariable String username,
                                                                        @RequestBody ProfileIntroRequest updateRequest) {
         memberService.updateProfileIntro(member, username, updateRequest);
         return ResponseEntity.ok().build();


### PR DESCRIPTION
### 작업 내용
- 누락되어 있는 API를 찾아 추가했습니다. 
- 엘서 관련 테스트가 간혹 깨져서 안정화되기 이전까지 주석처리 했습니다. 
- 누군가 build.gradle에 restdocs 스크립트를 주석처리해서 해제했습니다. (문서가 최신화 되지 않았던 이유) 


### 이슈
- posts -> studylogs로 변경하여 이전내용에 deprecated 된 것들이 코드와 문서에 혼재되어 있어 한번 정리해야할 것 같습니다. 
   - 현재는 @deprecated 어노테이션으로 구분 중인데 가독성이 좋은 것 같지는 않습니다. 
- scrap 관련 API가 어색한 것 같아서 이슈등록 했습니다. #750 

resolves #708 