### PR TITLE
refactor: 인기 학습 로그 카드에서 scrollbar 숨김 처리

### DIFF
--- a/frontend/src/components/Items/PopularStudylogItem.tsx
+++ b/frontend/src/components/Items/PopularStudylogItem.tsx
@@ -28,6 +28,7 @@ import { ReactComponent as LikedIcon } from '../../assets/images/heart-filled.sv
 import { ReactComponent as UnLikeIcon } from '../../assets/images/heart.svg';
 
 import type { Studylog } from '../../models/Studylogs';
+import { ScrollStyle } from '../../pages/MainPage/styles';
 
 const PopularStudylogItem = ({ item }: { item: Studylog }) => {
   const {
@@ -85,14 +86,7 @@ const PopularStudylogItem = ({ item }: { item: Studylog }) => {
 
           <div>
             {/* 태그 영역 */}
-            <ul
-              css={[
-                FlexStyle,
-                css`
-                  overflow: scroll;
-                `,
-              ]}
-            >
+            <ul css={[FlexStyle, ScrollStyle]}>
               {tags.slice(0, 2).map(({ name: tagName, id: tagId }) => (
                 <Link to={`${PATH.STUDYLOGS}?tags=${tagId}`} key={tagId}>
                   <Chip title={tagName} onClick={() => {}}>

--- a/frontend/src/pages/MainPage/PopularStudyLogList.tsx
+++ b/frontend/src/pages/MainPage/PopularStudyLogList.tsx
@@ -6,8 +6,10 @@ import { Studylog } from '../../models/Studylogs';
 import {
   PopularStudylogListRightControlStyle,
   PopularStudylogListStyle,
+  ScrollStyle,
   SectionHeaderGapStyle,
 } from './styles';
+
 import PopularStudylogItem from '../../components/Items/PopularStudylogItem';
 
 const PopularStudyLogList = ({ studylogs }: { studylogs: Studylog[] }): JSX.Element => {
@@ -19,7 +21,7 @@ const PopularStudyLogList = ({ studylogs }: { studylogs: Studylog[] }): JSX.Elem
       `}
     >
       <h2 css={[SectionHeaderGapStyle]}>😎 인기있는 학습로그</h2>
-      <ul css={[PopularStudylogListStyle]}>
+      <ul css={[PopularStudylogListStyle, ScrollStyle]}>
         {studylogs?.map((item: Studylog) => (
           <li key={item.id}>
             <PopularStudylogItem item={item} />

--- a/frontend/src/pages/MainPage/styles.ts
+++ b/frontend/src/pages/MainPage/styles.ts
@@ -69,7 +69,7 @@ export const PopularStudylogListRightControlStyle = css`
 `;
 
 export const ScrollStyle = css`
-  overflow: scroll;
+  overflow: auto;
   ::-webkit-scrollbar {
     display: none;
     width: 0;

--- a/frontend/src/pages/MainPage/styles.ts
+++ b/frontend/src/pages/MainPage/styles.ts
@@ -67,3 +67,11 @@ export const PopularStudylogListRightControlStyle = css`
     }
   }
 `;
+
+export const ScrollStyle = css`
+  overflow: scroll;
+  ::-webkit-scrollbar {
+    display: none;
+    width: 0;
+  }
+`;


### PR DESCRIPTION
#817 

### 개선 사항
- [x] 인기 있는 학습 로그 카드 내 tag들에 걸린 스크롤바 디자인을 수정하여 숨긴다.
- [x] 인기 있는 학습 로그 섹션 전체에 걸린 스크롤바 디자인을 수정하여 숨긴다.

### 기존
![image](https://user-images.githubusercontent.com/41886825/166208328-2bf8a36e-a6c6-4e1d-b5d6-07fc1b96facd.png)

### 개선 후
![image](https://user-images.githubusercontent.com/41886825/166208232-b56de864-6f3e-4d5d-84e4-7382cbde23a1.png)

close #817 
