### PR TITLE
fix: 임시저장 관련 버그 수정

### DIFF
--- a/backend/src/main/java/wooteco/prolog/studylog/application/StudylogService.java
+++ b/backend/src/main/java/wooteco/prolog/studylog/application/StudylogService.java
@@ -205,10 +205,12 @@ public class StudylogService {
     public StudylogTempResponse insertStudylogTemp(Long memberId, StudylogRequest studylogRequest) {
         Member member = memberService.findById(memberId);
         Tags tags = tagService.findOrCreate(studylogRequest.getTags());
+        Session session = sessionService.findById(studylogRequest.getSessionId());
         Mission mission = missionService.findById(studylogRequest.getMissionId());
         StudylogTemp requestedStudylogTemp = new StudylogTemp(member,
             studylogRequest.getTitle(),
             studylogRequest.getContent(),
+            session,
             mission,
             tags.getList());
 

--- a/backend/src/main/java/wooteco/prolog/studylog/application/StudylogService.java
+++ b/backend/src/main/java/wooteco/prolog/studylog/application/StudylogService.java
@@ -99,6 +99,24 @@ public class StudylogService {
         return StudylogResponse.of(persistStudylog);
     }
 
+    @Transactional
+    public StudylogTempResponse insertStudylogTemp(Long memberId, StudylogRequest studylogRequest) {
+        Member member = memberService.findById(memberId);
+        Tags tags = tagService.findOrCreate(studylogRequest.getTags());
+        Session session = sessionService.findSessionById(studylogRequest.getSessionId()).orElse(null);
+        Mission mission = missionService.findMissionById(studylogRequest.getMissionId()).orElse(null);
+        StudylogTemp requestedStudylogTemp = new StudylogTemp(member,
+                studylogRequest.getTitle(),
+                studylogRequest.getContent(),
+                session,
+                mission,
+                tags.getList());
+
+        deleteStudylogTemp(memberId);
+        StudylogTemp createdStudylogTemp = studylogTempRepository.save(requestedStudylogTemp);
+        return StudylogTempResponse.from(createdStudylogTemp);
+    }
+
     private void onStudylogCreatedEvent(Member foundMember, Tags tags, Studylog createdStudylog) {
         memberTagService.registerMemberTag(tags, foundMember);
         studylogDocumentService.save(createdStudylog.toStudylogDocument());
@@ -199,24 +217,6 @@ public class StudylogService {
     public Page<Studylog> findStudylogsByUsername(String username, Pageable pageable) {
         Member member = memberService.findByUsername(username);
         return studylogRepository.findByMember(member, pageable);
-    }
-
-    @Transactional
-    public StudylogTempResponse insertStudylogTemp(Long memberId, StudylogRequest studylogRequest) {
-        Member member = memberService.findById(memberId);
-        Tags tags = tagService.findOrCreate(studylogRequest.getTags());
-        Session session = sessionService.findById(studylogRequest.getSessionId());
-        Mission mission = missionService.findById(studylogRequest.getMissionId());
-        StudylogTemp requestedStudylogTemp = new StudylogTemp(member,
-            studylogRequest.getTitle(),
-            studylogRequest.getContent(),
-            session,
-            mission,
-            tags.getList());
-
-        deleteStudylogTemp(memberId);
-        StudylogTemp createdStudylogTemp = studylogTempRepository.save(requestedStudylogTemp);
-        return StudylogTempResponse.from(createdStudylogTemp);
     }
 
     private void deleteStudylogTemp(Long memberId) {

--- a/backend/src/main/java/wooteco/prolog/studylog/application/StudylogService.java
+++ b/backend/src/main/java/wooteco/prolog/studylog/application/StudylogService.java
@@ -105,6 +105,7 @@ public class StudylogService {
         Tags tags = tagService.findOrCreate(studylogRequest.getTags());
         Session session = sessionService.findSessionById(studylogRequest.getSessionId()).orElse(null);
         Mission mission = missionService.findMissionById(studylogRequest.getMissionId()).orElse(null);
+
         StudylogTemp requestedStudylogTemp = new StudylogTemp(member,
                 studylogRequest.getTitle(),
                 studylogRequest.getContent(),

--- a/backend/src/main/java/wooteco/prolog/studylog/application/dto/StudylogResponse.java
+++ b/backend/src/main/java/wooteco/prolog/studylog/application/dto/StudylogResponse.java
@@ -124,7 +124,6 @@ public class StudylogResponse {
     }
 
     public static StudylogResponse of(Studylog studylog, Session session, Mission mission) {
-
         return StudylogResponse.of(studylog, false, false, false, session, mission);
     }
 

--- a/backend/src/main/java/wooteco/prolog/studylog/application/dto/StudylogTempResponse.java
+++ b/backend/src/main/java/wooteco/prolog/studylog/application/dto/StudylogTempResponse.java
@@ -4,6 +4,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import wooteco.prolog.member.application.dto.MemberResponse;
 import wooteco.prolog.session.application.dto.MissionResponse;
+import wooteco.prolog.session.application.dto.SessionResponse;
 import wooteco.prolog.studylog.domain.StudylogTags;
 import wooteco.prolog.studylog.domain.StudylogTemp;
 
@@ -19,13 +20,15 @@ public class StudylogTempResponse {
     private MemberResponse author;
     private String title;
     private String content;
+    private SessionResponse session;
     private MissionResponse mission;
     private List<TagResponse> tags;
 
-    private StudylogTempResponse(MemberResponse author, String title, String content, MissionResponse mission, List<TagResponse> tags) {
+    private StudylogTempResponse(MemberResponse author, String title, String content, SessionResponse session, MissionResponse mission, List<TagResponse> tags) {
         this.author = author;
         this.title = title;
         this.content = content;
+        this.session = session;
         this.mission = mission;
         this.tags = tags;
     }
@@ -35,6 +38,7 @@ public class StudylogTempResponse {
                 MemberResponse.of(studylogTemp.getMember()),
                 studylogTemp.getTitle(),
                 studylogTemp.getContent(),
+                SessionResponse.of(studylogTemp.getSession()),
                 MissionResponse.of(studylogTemp.getMission()),
                 toTagResponses(studylogTemp.getStudylogTags()));
     }
@@ -47,6 +51,6 @@ public class StudylogTempResponse {
     }
 
     public static StudylogTempResponse toNull() {
-        return new StudylogTempResponse(null, null, null, null, null);
+        return new StudylogTempResponse(null, null, null, null, null, null);
     }
 }

--- a/backend/src/main/java/wooteco/prolog/studylog/application/dto/StudylogTempResponse.java
+++ b/backend/src/main/java/wooteco/prolog/studylog/application/dto/StudylogTempResponse.java
@@ -5,8 +5,8 @@ import lombok.NoArgsConstructor;
 import wooteco.prolog.member.application.dto.MemberResponse;
 import wooteco.prolog.session.application.dto.MissionResponse;
 import wooteco.prolog.session.application.dto.SessionResponse;
-import wooteco.prolog.studylog.domain.StudylogTags;
 import wooteco.prolog.studylog.domain.StudylogTemp;
+import wooteco.prolog.studylog.domain.StudylogTempTags;
 
 import java.util.List;
 
@@ -40,11 +40,11 @@ public class StudylogTempResponse {
                 studylogTemp.getContent(),
                 SessionResponse.of(studylogTemp.getSession()),
                 MissionResponse.of(studylogTemp.getMission()),
-                toTagResponses(studylogTemp.getStudylogTags()));
+                toTagResponses(studylogTemp.getStudylogTempTags()));
     }
 
     //todo TagResponse의 정적팩토리메서드로 리팩터링
-    private static List<TagResponse> toTagResponses(StudylogTags tags) {
+    private static List<TagResponse> toTagResponses(StudylogTempTags tags) {
         return tags.getValues().stream()
                 .map(tag -> TagResponse.of(tag.getTag()))
                 .collect(toList());

--- a/backend/src/main/java/wooteco/prolog/studylog/domain/Studylog.java
+++ b/backend/src/main/java/wooteco/prolog/studylog/domain/Studylog.java
@@ -101,12 +101,6 @@ public class Studylog extends AuditingEntity {
         this.studylogTags.update(convertToStudylogTags(tags));
     }
 
-    private List<StudylogTag> convertToStudylogTags(Tags tags) {
-        return tags.getList().stream()
-            .map(tag -> new StudylogTag(this, tag))
-            .collect(Collectors.toList());
-    }
-
     public StudylogDocument toStudylogDocument() {
         return new StudylogDocument(
             this.getId(), this.getTitle(),
@@ -118,6 +112,12 @@ public class Studylog extends AuditingEntity {
 
     public void addTags(Tags tags) {
         studylogTags.add(convertToStudylogTags(tags));
+    }
+
+    private List<StudylogTag> convertToStudylogTags(Tags tags) {
+        return tags.getList().stream()
+                .map(tag -> new StudylogTag(this, tag))
+                .collect(Collectors.toList());
     }
 
     public void increaseViewCount(Member member) {

--- a/backend/src/main/java/wooteco/prolog/studylog/domain/StudylogTags.java
+++ b/backend/src/main/java/wooteco/prolog/studylog/domain/StudylogTags.java
@@ -32,11 +32,10 @@ public class StudylogTags {
         values.addAll(duplicateFilter(studylogTags));
     }
 
-    private List<StudylogTag> duplicateFilter(
-        List<wooteco.prolog.studylog.domain.StudylogTag> studylogTags) {
+    private List<StudylogTag> duplicateFilter(List<StudylogTag> studylogTags) {
         return studylogTags.stream()
             .filter(studylogTag -> values.stream()
-                .map(wooteco.prolog.studylog.domain.StudylogTag::getTag)
+                .map(StudylogTag::getTag)
                 .noneMatch(newTag -> newTag.isSameName(studylogTag.getTag())))
             .collect(Collectors.toList());
     }

--- a/backend/src/main/java/wooteco/prolog/studylog/domain/StudylogTemp.java
+++ b/backend/src/main/java/wooteco/prolog/studylog/domain/StudylogTemp.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import wooteco.prolog.member.domain.Member;
 import wooteco.prolog.session.domain.Mission;
+import wooteco.prolog.session.domain.Session;
 
 import javax.persistence.*;
 import java.util.List;
@@ -28,16 +29,21 @@ public class StudylogTemp {
     private String content;
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "session_id")
+    private Session session;
+
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "mission_id")
     private Mission mission;
 
     @Embedded
     private StudylogTags studylogTags;
 
-    public StudylogTemp(Member member, String title, String content, Mission mission, List<Tag> tags) {
+    public StudylogTemp(Member member, String title, String content, Session session, Mission mission, List<Tag> tags) {
         this.member = member;
         this.title = title;
         this.content = content;
+        this.session = session;
         this.mission = mission;
         Tags tags1 = new Tags(tags);
         this.studylogTags = new StudylogTags(tags1.getList().stream()

--- a/backend/src/main/java/wooteco/prolog/studylog/domain/StudylogTemp.java
+++ b/backend/src/main/java/wooteco/prolog/studylog/domain/StudylogTemp.java
@@ -37,17 +37,17 @@ public class StudylogTemp {
     private Mission mission;
 
     @Embedded
-    private StudylogTags studylogTags;
+    private StudylogTempTags studylogTempTags;
 
-    public StudylogTemp(Member member, String title, String content, Session session, Mission mission, List<Tag> tags) {
+    public StudylogTemp(Member member, String title, String content, Session session, Mission mission, List<Tag> tagList) {
         this.member = member;
         this.title = title;
         this.content = content;
         this.session = session;
         this.mission = mission;
-        Tags tags1 = new Tags(tags);
-        this.studylogTags = new StudylogTags(tags1.getList().stream()
-                .map(tag -> new StudylogTag(null, tag))
+        Tags tags = new Tags(tagList);
+        this.studylogTempTags = new StudylogTempTags(tags.getList().stream()
+                .map(tag -> new StudylogTempTag(this, tag))
                 .collect(toList()));
     }
 }

--- a/backend/src/main/java/wooteco/prolog/studylog/domain/StudylogTempTag.java
+++ b/backend/src/main/java/wooteco/prolog/studylog/domain/StudylogTempTag.java
@@ -1,0 +1,57 @@
+package wooteco.prolog.studylog.domain;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.util.Objects;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class StudylogTempTag {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "tag_id")
+    private Tag tag;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "studylog_temp_id", nullable = false)
+    private StudylogTemp studylogTemp;
+
+    public StudylogTempTag(StudylogTemp studylogTemp, Tag tag) {
+        this(null, studylogTemp, tag);
+    }
+
+    public StudylogTempTag(Long id, StudylogTemp studylogTemp, Tag tag) {
+        this.id = id;
+        this.studylogTemp = studylogTemp;
+        this.tag = tag;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof StudylogTempTag)) {
+            return false;
+        }
+        StudylogTempTag studylogTempTag = (StudylogTempTag) o;
+        return Objects.equals(id, studylogTempTag.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+}

--- a/backend/src/main/java/wooteco/prolog/studylog/domain/StudylogTempTags.java
+++ b/backend/src/main/java/wooteco/prolog/studylog/domain/StudylogTempTags.java
@@ -1,0 +1,26 @@
+package wooteco.prolog.studylog.domain;
+
+import lombok.Getter;
+import org.hibernate.annotations.BatchSize;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Embeddable;
+import javax.persistence.OneToMany;
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Embeddable
+public class StudylogTempTags {
+    @OneToMany(mappedBy = "studylogTemp", cascade = CascadeType.PERSIST, orphanRemoval = true)
+    @BatchSize(size = 1000)
+    private final List<StudylogTempTag> values;
+
+    public StudylogTempTags() {
+        this(new ArrayList<>());
+    }
+
+    public StudylogTempTags(List<StudylogTempTag> values) {
+        this.values = values;
+    }
+}

--- a/backend/src/main/resources/db/migration/prod/V24__add_session_column_to_studylogtemp.sql
+++ b/backend/src/main/resources/db/migration/prod/V24__add_session_column_to_studylogtemp.sql
@@ -1,0 +1,6 @@
+ALTER TABLE studylog_temp ADD COLUMN session_id BIGINT;
+
+alter table studylog_temp
+    add constraint FK_STUDYLOG_TEMP_SESSION
+        foreign key (session_id)
+            references session (id) on delete cascade;

--- a/backend/src/main/resources/db/migration/prod/V25__create_studylogtemptag_table.sql
+++ b/backend/src/main/resources/db/migration/prod/V25__create_studylogtemptag_table.sql
@@ -1,0 +1,16 @@
+create table studylog_temp_tag (
+                               id bigint not null auto_increment,
+                               tag_id bigint
+                               studylog_temp_id bigint not null,
+                               primary key (id)
+) engine=InnoDB;
+
+alter table studylog_temp_tag
+    add constraint FK_STUDYLOG_TEMP_TAG_TAG
+        foreign key (tag_id)
+            references tag (id) on delete cascade;
+
+alter table studylog_temp_tag
+    add constraint FK_STUDYLOG_TEMP_TAG_STUDYLOG_TEMP
+        foreign key (studylog_temp_id)
+            references studylog_temp (id) on delete cascade;

--- a/backend/src/test/java/wooteco/prolog/studylog/studylog/domain/TitleTest.java
+++ b/backend/src/test/java/wooteco/prolog/studylog/studylog/domain/TitleTest.java
@@ -42,5 +42,4 @@ class TitleTest {
         assertThat(title2.getTitle()).isEqualTo(expectedText);
         assertThat(title3.getTitle()).isEqualTo(expectedText);
     }
-
 }


### PR DESCRIPTION
- [x] `POST API` mission이 null 일 때 임시저장이 되지 않는 문제
- [x] `PUT API`, `GET API` tags가 자동으로 포함되어 오는 문제
- [x] 학습로그 응답에 session 항목도 추가 (변경된 학습로그 응답에 맞춰 통일)

Close #879 