### PR TITLE
feat: 학습로그와 역량 매핑 오류 수정

### DIFF
--- a/backend/src/main/java/wooteco/prolog/ability/domain/Ability.java
+++ b/backend/src/main/java/wooteco/prolog/ability/domain/Ability.java
@@ -185,6 +185,6 @@ public class Ability {
     }
 
     public boolean isBelongsTo(Long memberId) {
-        return this.member.getId() == memberId;
+        return this.member.getId().equals(memberId);
     }
 }

--- a/backend/src/test/java/wooteco/prolog/report/domain/ablity/AbilityTest.java
+++ b/backend/src/test/java/wooteco/prolog/report/domain/ablity/AbilityTest.java
@@ -102,4 +102,15 @@ class AbilityTest {
         assertThatThrownBy(() -> childAbility.validateColorWithParent(Collections.singletonList(anotherParentAbility), parentAbility))
             .isExactlyInstanceOf(AbilityParentChildColorDifferentException.class);
     }
+
+    @DisplayName("역량이 멤버에게 속하는지 확인한다.")
+    @Test
+    void isBelongsToMember() {
+        Long abilityId = 1L;
+        Long memberId = 100_000L;
+        Member member = new Member(100_000L, null, null, null, null, null);
+
+        Ability ability = Ability.parent(abilityId, "역량", "역량 매핑", "파란색", member);
+        assertThat(ability.isBelongsTo(memberId)).isTrue();
+    }
 }


### PR DESCRIPTION
## as-is
일부 크루들이 학습로그와 역량을 매핑하려고 할 때 오류가 발생하였다.
![역량_매핑_오류](https://user-images.githubusercontent.com/42317507/182009505-dd47d60c-fc44-4dd8-9c24-3223466748df.gif)


## to-be
해당 오류를 수정하여 모든 크루들이 학습로그와 역량을 매핑시킬 수 있다.