### PR TITLE
refactor: custom fetch hook을 React Query로 마이그레이션 (Introduction, ProfilePageSideBar, ProfilePageScraps)

### DIFF
--- a/frontend/src/hooks/queries/profile.ts
+++ b/frontend/src/hooks/queries/profile.ts
@@ -1,0 +1,26 @@
+import { useMutation, useQuery, useQueryClient } from 'react-query';
+import { requestDeleteScrap, requestGetMyScrap } from '../../service/requests';
+
+const QUERY_KEY = {
+  scrap: 'scrap',
+};
+
+export const useGetMyScrapQuery = ({ username, accessToken, postQueryParams }) => {
+  return useQuery([QUERY_KEY.scrap, postQueryParams.page], () =>
+    requestGetMyScrap({
+      username,
+      accessToken,
+      postQueryParams,
+    }).then((res) => res.json())
+  );
+};
+
+export const useDeleteScrapMutation = (options) => {
+  const queryClient = useQueryClient();
+
+  return useMutation(requestDeleteScrap, {
+    onSuccess() {
+      queryClient.invalidateQueries([QUERY_KEY.scrap]);
+    },
+  });
+};

--- a/frontend/src/hooks/queries/profile.ts
+++ b/frontend/src/hooks/queries/profile.ts
@@ -1,8 +1,14 @@
 import { useMutation, useQuery, useQueryClient } from 'react-query';
-import { requestDeleteScrap, requestGetMyScrap } from '../../service/requests';
+import {
+  requestDeleteScrap,
+  requestEditProfile,
+  requestGetMyScrap,
+  requestGetProfile,
+} from '../../service/requests';
 
 const QUERY_KEY = {
   scrap: 'scrap',
+  profile: 'profile',
 };
 
 export const useGetMyScrapQuery = ({ username, accessToken, postQueryParams }) => {
@@ -15,7 +21,7 @@ export const useGetMyScrapQuery = ({ username, accessToken, postQueryParams }) =
   );
 };
 
-export const useDeleteScrapMutation = (options) => {
+export const useDeleteScrapMutation = () => {
   const queryClient = useQueryClient();
 
   return useMutation(requestDeleteScrap, {
@@ -23,4 +29,33 @@ export const useDeleteScrapMutation = (options) => {
       queryClient.invalidateQueries([QUERY_KEY.scrap]);
     },
   });
+};
+
+export const useGetProfileQuery = ({ username }, { onSuccess }) => {
+  return useQuery(QUERY_KEY.profile, () => requestGetProfile(username).then((res) => res.json()), {
+    onSuccess: (data) => {
+      onSuccess(data);
+    },
+  });
+};
+
+export const usePutProfileMutation = ({ user, nickname, accessToken }, { onSuccess }) => {
+  const queryClient = useQueryClient();
+
+  return useMutation(
+    () =>
+      requestEditProfile(
+        { username: user.username, nickname: nickname, imageUrl: user.imageUrl },
+        accessToken
+      ),
+    {
+      onSuccess: () => {
+        queryClient.invalidateQueries([QUERY_KEY.profile]);
+        onSuccess();
+      },
+      onError: () => {
+        alert('회원 정보 수정에 실패했습니다.');
+      },
+    }
+  );
 };

--- a/frontend/src/hooks/queries/profile.ts
+++ b/frontend/src/hooks/queries/profile.ts
@@ -2,13 +2,16 @@ import { useMutation, useQuery, useQueryClient } from 'react-query';
 import {
   requestDeleteScrap,
   requestEditProfile,
-  requestGetMyScrap,
   requestGetProfile,
+  requestEditProfileIntroduction,
+  requestGetMyScrap,
+  requestGetProfileIntroduction,
 } from '../../service/requests';
 
 const QUERY_KEY = {
   scrap: 'scrap',
   profile: 'profile',
+  introduction: 'introduction',
 };
 
 export const useGetMyScrapQuery = ({ username, accessToken, postQueryParams }) => {
@@ -59,3 +62,22 @@ export const usePutProfileMutation = ({ user, nickname, accessToken }, { onSucce
     }
   );
 };
+export const usePutProfileIntroductionMutation = (
+  { username, editorContentRef, accessToken },
+  options
+) => {
+  return useMutation(
+    () =>
+      requestEditProfileIntroduction(
+        username,
+        editorContentRef.current.getInstance().getMarkdown(),
+        accessToken
+      ),
+    options
+  );
+};
+
+export const useGetProfileIntroduction = ({ username }) =>
+  useQuery(QUERY_KEY.introduction, () =>
+    requestGetProfileIntroduction(username).then((res) => res.json())
+  );

--- a/frontend/src/pages/ProfilePageScraps/index.js
+++ b/frontend/src/pages/ProfilePageScraps/index.js
@@ -1,9 +1,6 @@
-import { useContext, useEffect, useState } from 'react';
+import { useContext, useState } from 'react';
 import { useHistory, useParams } from 'react-router-dom';
 
-import useRequest from '../../hooks/useRequest';
-import useMutation from '../../hooks/useMutation';
-import { requestDeleteScrap, requestGetMyScrap } from '../../service/requests';
 import { UserContext } from '../../contexts/UserProvider';
 
 import { Button, BUTTON_SIZE, Card, Pagination } from '../../components';
@@ -24,7 +21,7 @@ import {
   Title,
   Heading,
 } from './styles';
-import { useDeleteScrapMutation, useFetchMyScrap } from '../../hooks/queries/profile';
+import { useDeleteScrapMutation, useGetMyScrapQuery } from '../../hooks/queries/profile';
 
 const initialPostQueryParams = {
   page: 1,
@@ -46,7 +43,7 @@ const ProfilePageScraps = () => {
     history.push(`${PATH.STUDYLOG}/${id}`);
   };
 
-  const { data: studylogs } = useFetchMyScrap({ username, accessToken, postQueryParams });
+  const { data: studylogs } = useGetMyScrapQuery({ username, accessToken, postQueryParams });
 
   const onSetPage = (page) => {
     setPostQueryParams({ ...postQueryParams, page });

--- a/frontend/src/pages/ProfilePageScraps/index.js
+++ b/frontend/src/pages/ProfilePageScraps/index.js
@@ -24,6 +24,7 @@ import {
   Title,
   Heading,
 } from './styles';
+import { useDeleteScrapMutation, useFetchMyScrap } from '../../hooks/queries/profile';
 
 const initialPostQueryParams = {
   page: 1,
@@ -45,19 +46,13 @@ const ProfilePageScraps = () => {
     history.push(`${PATH.STUDYLOG}/${id}`);
   };
 
-  const { response: studylogs, fetchData: getMyScrap } = useRequest([], () =>
-    requestGetMyScrap({ username, accessToken, postQueryParams })
-  );
+  const { data: studylogs } = useFetchMyScrap({ username, accessToken, postQueryParams });
 
   const onSetPage = (page) => {
     setPostQueryParams({ ...postQueryParams, page });
   };
 
-  const { mutate: deleteScrap } = useMutation(requestDeleteScrap, {
-    onSuccess: () => {
-      getMyScrap();
-    },
-  });
+  const deleteScrapMutation = useDeleteScrapMutation();
 
   const onDeleteScrap = async (event, id) => {
     event.stopPropagation();
@@ -66,12 +61,8 @@ const ProfilePageScraps = () => {
       return;
     }
 
-    deleteScrap({ username, accessToken, id });
+    deleteScrapMutation.mutate({ username, accessToken, id });
   };
-
-  useEffect(() => {
-    getMyScrap();
-  }, [postQueryParams]);
 
   return (
     <Container>


### PR DESCRIPTION
custom fetch hook을 React Query로 마이그레이션

react query 커스텀훅을 hooks/queries 폴더에 도메인 별로 분리하였습니다.
그리고 해당 파일에 도메인 별로 query key 상수화를 하였습니다.

- [x] Introduction.js
   - useMutation, useRequest 
- [x] ProfilePageSideBar.js
   - useMutation, useRequest 
- [x] ProfilePageScraps.js
   - useMutation

close #948 

