### PR TITLE
fix: 댓글 작성 날짜 형식 수정

### DIFF
--- a/frontend/src/components/Comment/Comment.tsx
+++ b/frontend/src/components/Comment/Comment.tsx
@@ -79,7 +79,7 @@ const Comment = ({ id, author, content, createAt, editComment, deleteComment }: 
               <Styled.Logo src={imageUrl} alt="프로필" />
               <span>{nickname}</span>
             </Link>
-            <Styled.CreatedDate>{createAt}</Styled.CreatedDate>
+            <Styled.CreatedDate>{new Date(createAt).toLocaleString('ko-KR')}</Styled.CreatedDate>
           </Styled.Left>
           {user.userId === author.id && (
             <Styled.Right>


### PR DESCRIPTION
## 변경 
API 명세가 `YYYY-MM-DD` 형식으로 하기로 했다가, `YYYY-MM-DD hh-mm-ss` 형식으로 변경하기로 했습니다.
그에 따라 날짜 형식을 수정했습니다.

게시물에서 보이는 형식과 같이 `2022. 9. 4. 오후 4:51:54` 처럼 보여줍니다.

### 추후 개선 사항
빠른 시일 내에, `5분 전`, `10시간 전`, `4일 전` 형식으로 표현하고자 합니다.
[이슈](https://github.com/woowacourse/prolog/issues/1001) 파두었습니다.
