### PR TITLE
chore: 링크 새 탭에서 열기 및 인기있는 학습로그 높이 증가

### DIFF
--- a/frontend/src/components/Editor/SideBar/StudyLogSelectAbilityBox.js
+++ b/frontend/src/components/Editor/SideBar/StudyLogSelectAbilityBox.js
@@ -63,7 +63,9 @@ const StudyLogSelectAbilityBox = ({
         <p id="selectBox-title">학습로그에 매핑될 역량을 선택해주세요.</p>
         <span className="ability-title">📢 역량은 하위역량만 선택가능합니다.</span>
         <span className="ability-link">
-          <Link to={`/${username}/ability`}>역량 관리 페이지 이동</Link>
+          <Link to={`/${username}/ability`} target="_blank">
+            역량 관리 페이지 이동
+          </Link>
         </span>
         <Styled.CloseButton onClick={onClickCloseButton}></Styled.CloseButton>
         <Styled.SearchInput

--- a/frontend/src/pages/MainPage/styles.ts
+++ b/frontend/src/pages/MainPage/styles.ts
@@ -20,7 +20,7 @@ export const SectionHeaderGapStyle = css`
 // 인기있는 학습로그
 export const PopularStudylogListStyle = css`
   width: 100%;
-  height: 30rem;
+  height: 32rem;
 
   display: flex;
   justify-content: content;


### PR DESCRIPTION
- 역량관리페이지 이동 링크를 새 탭에서 열기
	- 학습로그 작성 도중 역량관리페이지 이동 링크를 눌러서 작성 중인 글을 잃지 않도록 새 탭으로 열도록 변경한다
- 인기있는 학습로그 아이템 높이 증가
	- 인기있는 학습로그 아이템에 마우스를 올리면 살짝 올라오는데, 현재 상단이 약간 잘리므로, 여유있게 높이를 증가한다
