### PR TITLE
feat: 레벨로그 댓글 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 
 # Mac
 .DS_Store
+
+/.vscode

--- a/frontend/src/apis/levellogComment.ts
+++ b/frontend/src/apis/levellogComment.ts
@@ -1,0 +1,34 @@
+import { client } from '.';
+import { CommentListResponse, CommentRequest } from '../models/Comment';
+
+export const getLevellogComments = async (levellogId: number): Promise<CommentListResponse> => {
+  const response = await client.get(`/levellogs/${levellogId}/comments`);
+
+  return response.data;
+};
+
+export const createLevellogComment = ({
+  levellogId,
+  body,
+}: {
+  levellogId: number;
+  body: CommentRequest;
+}) => client.post(`/levellogs/${levellogId}/comments`, body);
+
+export const editLevellogComment = ({
+  levellogId,
+  commentId,
+  body,
+}: {
+  levellogId: number;
+  commentId: number;
+  body: CommentRequest;
+}) => client.put(`/levellogs/${levellogId}/comments/${commentId}`, body);
+
+export const deleteLevellogComment = ({
+  levellogId,
+  commentId,
+}: {
+  levellogId: number;
+  commentId: number;
+}) => client.delete(`/levellogs/${levellogId}/comments/${commentId}`);

--- a/frontend/src/components/Comment/Comment.tsx
+++ b/frontend/src/components/Comment/Comment.tsx
@@ -22,7 +22,7 @@ export interface CommentProps extends CommentType {
   deleteComment: (commentId: number) => void;
 }
 
-const Comment = ({ id, author, content, createAt, editComment, deleteComment }: CommentProps) => {
+const Comment = ({ id, author, content, createdAt, editComment, deleteComment }: CommentProps) => {
   const { user } = useContext(UserContext);
   const { username, nickname, imageUrl } = author;
 
@@ -79,7 +79,7 @@ const Comment = ({ id, author, content, createAt, editComment, deleteComment }: 
               <Styled.Logo src={imageUrl} alt="프로필" />
               <span>{nickname}</span>
             </Link>
-            <Styled.CreatedDate>{new Date(createAt).toLocaleString('ko-KR')}</Styled.CreatedDate>
+            <Styled.CreatedDate>{new Date(createdAt).toLocaleString('ko-KR')}</Styled.CreatedDate>
           </Styled.Left>
           {user.userId === author.id && (
             <Styled.Right>

--- a/frontend/src/components/Comment/CommentEditorForm.style.tsx
+++ b/frontend/src/components/Comment/CommentEditorForm.style.tsx
@@ -1,0 +1,25 @@
+import styled from '@emotion/styled';
+import { COLOR } from '../../enumerations/color';
+
+export const EditorForm = styled.form`
+  & .toastui-editor-toolbar {
+    border-radius: 10px 10px 0 0;
+  }
+`;
+
+export const SubmitButton = styled.button`
+  width: 100%;
+  padding: 1rem 0;
+  border-radius: 1.6rem;
+
+  margin-top: 12px;
+
+  background-color: ${COLOR.LIGHT_BLUE_300};
+  :hover {
+    background-color: ${COLOR.LIGHT_BLUE_500};
+  }
+
+  :disabled {
+    background-color: ${COLOR.LIGHT_GRAY_300};
+  }
+`;

--- a/frontend/src/components/Comment/CommentEditorForm.tsx
+++ b/frontend/src/components/Comment/CommentEditorForm.tsx
@@ -1,0 +1,26 @@
+import React, { FormEventHandler, RefObject, useContext } from 'react';
+import { UserContext } from '../../contexts/UserProvider';
+import Editor from '../Editor/Editor';
+import { Editor as ToastEditor } from '@toast-ui/react-editor';
+import * as Styled from './CommentEditorForm.style';
+
+interface CommentEditorFormProps {
+  onSubmit: FormEventHandler;
+  editorContentRef: RefObject<ToastEditor>;
+}
+
+const CommentEditorForm = ({ onSubmit, editorContentRef }: CommentEditorFormProps) => {
+  const { user } = useContext(UserContext);
+  const { isLoggedIn } = user;
+
+  return (
+    <Styled.EditorForm onSubmit={onSubmit}>
+      <Editor height="25rem" hasTitle={false} editorContentRef={editorContentRef} />
+      <Styled.SubmitButton disabled={!isLoggedIn}>
+        {isLoggedIn ? '작성 완료' : '로그인 후 작성해주세요.'}
+      </Styled.SubmitButton>
+    </Styled.EditorForm>
+  );
+};
+
+export default CommentEditorForm;

--- a/frontend/src/components/Comment/CommentEditorForm.tsx
+++ b/frontend/src/components/Comment/CommentEditorForm.tsx
@@ -15,10 +15,13 @@ const CommentEditorForm = ({ onSubmit, editorContentRef }: CommentEditorFormProp
 
   return (
     <Styled.EditorForm onSubmit={onSubmit}>
-      <Editor height="25rem" hasTitle={false} editorContentRef={editorContentRef} />
-      <Styled.SubmitButton disabled={!isLoggedIn}>
-        {isLoggedIn ? '작성 완료' : '로그인 후 작성해주세요.'}
-      </Styled.SubmitButton>
+      <Editor
+        height="25rem"
+        hasTitle={false}
+        editorContentRef={editorContentRef}
+        placeholder={isLoggedIn || '로그인 후 작성해주세요.'}
+      />
+      {isLoggedIn && <Styled.SubmitButton disabled={!isLoggedIn}>작성 완료</Styled.SubmitButton>}
     </Styled.EditorForm>
   );
 };

--- a/frontend/src/components/Editor/Editor.tsx
+++ b/frontend/src/components/Editor/Editor.tsx
@@ -18,6 +18,7 @@ interface EditorProps {
   title?: string;
   hasTitle?: boolean;
   titlePlaceholder?: string;
+  placeholder?: string;
   editorContentRef: MutableRefObject<unknown>;
   content?: string | null;
   onChangeTitle?: ChangeEventHandler<HTMLInputElement>;
@@ -38,6 +39,7 @@ const Editor = (props: EditorProps): JSX.Element => {
     hasTitle = true,
     title = '',
     titlePlaceholder = '제목을 입력하세요',
+    placeholder,
     content,
     onChangeTitle,
     editorContentRef,
@@ -62,6 +64,7 @@ const Editor = (props: EditorProps): JSX.Element => {
           initialEditType="markdown"
           toolbarItems={toolbarItems}
           extendedAutolinks={true}
+          placeholder={placeholder}
           plugins={[[codeSyntaxHighlight, { highlighter: Prism }]]}
         />
       )}

--- a/frontend/src/components/NavBar/NavBar.js
+++ b/frontend/src/components/NavBar/NavBar.js
@@ -36,10 +36,10 @@ const navigationConfig = [
     path: PATH.STUDYLOG,
     title: '학습로그',
   },
-  // {
-  //   path: PATH.LEVELLOG,
-  //   title: '레벨로그',
-  // },
+  {
+    path: PATH.LEVELLOG,
+    title: '레벨로그',
+  },
 ];
 
 const NavBar = () => {
@@ -110,19 +110,17 @@ const NavBar = () => {
           </Navigation>
           {isLoggedIn ? (
             <>
-              <Link to={PATH.NEW_STUDYLOG}>
-                <Button
-                  size="XX_SMALL"
-                  icon={PencilIcon}
-                  type="button"
-                  onClick={(e) => {
-                    setWritingDropdownToggled(true);
-                    hideDropdownMenu(e);
-                  }}
-                  cssProps={pencilButtonStyle}
-                />
-              </Link>
-              {/* {isWritingDropdownToggled && (
+              <Button
+                size="XX_SMALL"
+                icon={PencilIcon}
+                type="button"
+                onClick={(e) => {
+                  setWritingDropdownToggled(true);
+                  hideDropdownMenu(e);
+                }}
+                cssProps={pencilButtonStyle}
+              />
+              {isWritingDropdownToggled && (
                 <DropdownMenu cssProps={WritingDropdownStyle}>
                   <ul onClick={onSelectMenu}>
                     {[
@@ -141,7 +139,7 @@ const NavBar = () => {
                     ))}
                   </ul>
                 </DropdownMenu>
-              )} */}
+              )}
               <Button
                 size="XX_SMALL"
                 type="button"

--- a/frontend/src/hooks/Comment/useStudylogComment.ts
+++ b/frontend/src/hooks/Comment/useStudylogComment.ts
@@ -1,3 +1,7 @@
+import { useRef } from 'react';
+import { Editor as ToastEditor } from '@toast-ui/react-editor';
+
+import { ALERT_MESSAGE } from '../../constants';
 import { CommentRequest } from '../../models/Comment';
 import {
   useCreateComment,
@@ -7,6 +11,8 @@ import {
 } from '../queries/comment';
 
 const useStudylogComment = (studylogId: number) => {
+  const editorContentRef = useRef<ToastEditor>(null);
+
   const { data } = useFetchComments(studylogId);
   const comments = data?.data;
 
@@ -26,11 +32,27 @@ const useStudylogComment = (studylogId: number) => {
     deleteCommentMutation.mutate(commentId);
   };
 
+  const onSubmitComment = (event) => {
+    event.preventDefault();
+
+    const content = editorContentRef.current?.getInstance().getMarkdown() || '';
+
+    if (content.length === 0) {
+      alert(ALERT_MESSAGE.NO_CONTENT);
+      return;
+    }
+
+    createComment({ content });
+    editorContentRef.current?.getInstance().setMarkdown('');
+  };
+
   return {
     comments,
+    editorContentRef,
     createComment,
     editComment,
     deleteComment,
+    onSubmitComment,
   };
 };
 

--- a/frontend/src/hooks/Comment/useStudylogComment.ts
+++ b/frontend/src/hooks/Comment/useStudylogComment.ts
@@ -1,4 +1,4 @@
-import { useRef } from 'react';
+import { FormEventHandler, useRef } from 'react';
 import { Editor as ToastEditor } from '@toast-ui/react-editor';
 
 import { ALERT_MESSAGE } from '../../constants';
@@ -32,7 +32,7 @@ const useStudylogComment = (studylogId: number) => {
     deleteCommentMutation.mutate(commentId);
   };
 
-  const onSubmitComment = (event) => {
+  const onSubmitComment: FormEventHandler = (event) => {
     event.preventDefault();
 
     const content = editorContentRef.current?.getInstance().getMarkdown() || '';

--- a/frontend/src/hooks/Levellog/useLevellogComment.ts
+++ b/frontend/src/hooks/Levellog/useLevellogComment.ts
@@ -1,0 +1,37 @@
+import { CommentRequest } from '../../models/Comment';
+import {
+  useCreateLevellogComment,
+  useDeleteLevellogCommentMutation,
+  useEditLevellogCommentMutation,
+  useFetchLevellogComments,
+} from '../queries/levellogComment';
+
+const useLevellogComment = (levellogId: number) => {
+  const { data } = useFetchLevellogComments(levellogId);
+  const levellogComments = data?.data;
+
+  const createLevellogCommentMutation = useCreateLevellogComment(levellogId);
+  const editLevellogCommentMutation = useEditLevellogCommentMutation(levellogId);
+  const deleteLevellogCommentMutation = useDeleteLevellogCommentMutation(levellogId);
+
+  const createLevellogComment = (body: CommentRequest) => {
+    createLevellogCommentMutation.mutate(body);
+  };
+
+  const editLevellogComment = (commentId: number, body: CommentRequest) => {
+    editLevellogCommentMutation.mutate({ commentId, body });
+  };
+
+  const deleteLevellogComment = (commentId: number) => {
+    deleteLevellogCommentMutation.mutate(commentId);
+  };
+
+  return {
+    levellogComments,
+    createLevellogComment,
+    editLevellogComment,
+    deleteLevellogComment,
+  };
+};
+
+export default useLevellogComment;

--- a/frontend/src/hooks/Levellog/useLevellogComment.ts
+++ b/frontend/src/hooks/Levellog/useLevellogComment.ts
@@ -1,3 +1,6 @@
+import { useRef } from 'react';
+import { Editor as ToastEditor } from '@toast-ui/react-editor';
+
 import { CommentRequest } from '../../models/Comment';
 import {
   useCreateLevellogComment,
@@ -5,8 +8,10 @@ import {
   useEditLevellogCommentMutation,
   useFetchLevellogComments,
 } from '../queries/levellogComment';
+import { ALERT_MESSAGE } from '../../constants';
 
 const useLevellogComment = (levellogId: number) => {
+  const editorContentRef = useRef<ToastEditor>(null);
   const { data } = useFetchLevellogComments(levellogId);
   const levellogComments = data?.data;
 
@@ -26,11 +31,27 @@ const useLevellogComment = (levellogId: number) => {
     deleteLevellogCommentMutation.mutate(commentId);
   };
 
+  const onSubmitLevellogComment = (event) => {
+    event.preventDefault();
+
+    const content = editorContentRef.current?.getInstance().getMarkdown() || '';
+
+    if (content.length === 0) {
+      alert(ALERT_MESSAGE.NO_CONTENT);
+      return;
+    }
+
+    createLevellogComment({ content });
+    editorContentRef.current?.getInstance().setMarkdown('');
+  };
+
   return {
     levellogComments,
+    editorContentRef,
     createLevellogComment,
     editLevellogComment,
     deleteLevellogComment,
+    onSubmitLevellogComment,
   };
 };
 

--- a/frontend/src/hooks/queries/levellogComment.ts
+++ b/frontend/src/hooks/queries/levellogComment.ts
@@ -1,0 +1,49 @@
+import { useMutation, useQuery, useQueryClient } from 'react-query';
+import {
+  createLevellogComment,
+  deleteLevellogComment,
+  editLevellogComment,
+  getLevellogComments,
+} from '../../apis/levellogComment';
+import { CommentRequest } from '../../models/Comment';
+
+const QUERY_KEY = {
+  levellogComments: 'levellogComments',
+};
+
+export const useFetchLevellogComments = (levellogId: number) =>
+  useQuery([QUERY_KEY.levellogComments, levellogId], () => getLevellogComments(levellogId));
+
+export const useCreateLevellogComment = (levellogId: number) => {
+  const queryClient = useQueryClient();
+
+  return useMutation((body: CommentRequest) => createLevellogComment({ levellogId, body }), {
+    onSuccess() {
+      queryClient.invalidateQueries([QUERY_KEY.levellogComments, levellogId]);
+    },
+  });
+};
+
+export const useEditLevellogCommentMutation = (levellogId: number) => {
+  const queryClient = useQueryClient();
+
+  return useMutation(
+    ({ commentId, body }: { commentId: number; body: CommentRequest }) =>
+      editLevellogComment({ levellogId, commentId, body }),
+    {
+      onSuccess() {
+        queryClient.invalidateQueries([QUERY_KEY.levellogComments, levellogId]);
+      },
+    }
+  );
+};
+
+export const useDeleteLevellogCommentMutation = (levellogId: number) => {
+  const queryClient = useQueryClient();
+
+  return useMutation((commentId: number) => deleteLevellogComment({ levellogId, commentId }), {
+    onSuccess() {
+      queryClient.invalidateQueries([QUERY_KEY.levellogComments, levellogId]);
+    },
+  });
+};

--- a/frontend/src/hooks/useBeforeunload.ts
+++ b/frontend/src/hooks/useBeforeunload.ts
@@ -1,7 +1,7 @@
 import { Editor as ToastEditor } from '@toast-ui/react-editor';
-import { useEffect, MutableRefObject } from 'react';
+import { useEffect, RefObject } from 'react';
 
-const useBeforeunload = (editorContentRef: MutableRefObject<ToastEditor>) => {
+const useBeforeunload = (editorContentRef: RefObject<ToastEditor>) => {
   useEffect(() => {
     window.addEventListener('beforeunload', (event) => {
       const content = editorContentRef.current?.getInstance().getMarkdown() || '';

--- a/frontend/src/mocks/db/comments.json
+++ b/frontend/src/mocks/db/comments.json
@@ -10,7 +10,7 @@
         "role": "crew"
       },
       "content": "내용1",
-      "createAt": "2022-07-24"
+      "createdAt": "2022-07-24"
     },
     {
       "id": 2,
@@ -22,7 +22,7 @@
         "role": "crew"
       },
       "content": "내용2",
-      "createAt": "2022-07-24"
+      "createdAt": "2022-07-24"
     }
   ]
 }

--- a/frontend/src/mocks/handlers/comment.ts
+++ b/frontend/src/mocks/handlers/comment.ts
@@ -22,7 +22,7 @@ export const commentsHandler = [
           role: 'crew',
         },
         content: body.content,
-        createAt: '2022-07-24',
+        createdAt: '2022-07-24',
       },
     ];
 

--- a/frontend/src/models/Comment.ts
+++ b/frontend/src/models/Comment.ts
@@ -4,7 +4,7 @@ export interface CommentType {
   id: number;
   author: Author;
   content: string;
-  createAt: string;
+  createdAt: string;
 }
 
 export interface CommentListResponse {

--- a/frontend/src/pages/LevellogPage/index.tsx
+++ b/frontend/src/pages/LevellogPage/index.tsx
@@ -9,8 +9,19 @@ import { MainContentStyle } from '../../PageRouter';
 import useLevellog from '../../hooks/Levellog/useLevellog';
 import QnAList from './QnAList';
 import { CONFIRM_MESSAGE } from '../../constants';
+import { useParams } from 'react-router-dom';
+import useLevellogComment from '../../hooks/Levellog/useLevellogComment';
+import Editor from '../../components/Editor/Editor';
+import { EditorForm, SubmitButton } from '../StudylogPage/styles';
+import CommentList from '../../components/Comment/CommentList';
+import { useContext } from 'react';
+import { UserContext } from '../../contexts/UserProvider';
 
 const LevellogPage = () => {
+  const { id } = useParams<{ id: string }>();
+  const { user } = useContext(UserContext);
+  const { isLoggedIn } = user;
+
   const {
     levellog,
     deleteLevellog,
@@ -18,6 +29,14 @@ const LevellogPage = () => {
     isLoading,
     goEditTargetPost,
   } = useLevellog();
+
+  const {
+    levellogComments,
+    editorContentRef,
+    editLevellogComment,
+    deleteLevellogComment,
+    onSubmitLevellogComment,
+  } = useLevellogComment(Number(id));
 
   return (
     <div css={MainContentStyle}>
@@ -53,6 +72,19 @@ const LevellogPage = () => {
           <Content levellog={levellog} />
           <QnAList QnAList={levellog?.levelLogs} />
         </>
+      )}
+      {levellogComments && (
+        <CommentList
+          comments={levellogComments}
+          editComment={editLevellogComment}
+          deleteComment={deleteLevellogComment}
+        />
+      )}
+      {isLoggedIn && (
+        <EditorForm onSubmit={onSubmitLevellogComment}>
+          <Editor height="25rem" hasTitle={false} editorContentRef={editorContentRef} />
+          <SubmitButton>작성 완료</SubmitButton>
+        </EditorForm>
       )}
     </div>
   );

--- a/frontend/src/pages/LevellogPage/index.tsx
+++ b/frontend/src/pages/LevellogPage/index.tsx
@@ -16,6 +16,7 @@ import { EditorForm, SubmitButton } from '../StudylogPage/styles';
 import CommentList from '../../components/Comment/CommentList';
 import { useContext } from 'react';
 import { UserContext } from '../../contexts/UserProvider';
+import CommentEditorForm from '../../components/Comment/CommentEditorForm';
 
 const LevellogPage = () => {
   const { id } = useParams<{ id: string }>();
@@ -80,12 +81,7 @@ const LevellogPage = () => {
           deleteComment={deleteLevellogComment}
         />
       )}
-      {isLoggedIn && (
-        <EditorForm onSubmit={onSubmitLevellogComment}>
-          <Editor height="25rem" hasTitle={false} editorContentRef={editorContentRef} />
-          <SubmitButton>작성 완료</SubmitButton>
-        </EditorForm>
-      )}
+      <CommentEditorForm onSubmit={onSubmitLevellogComment} editorContentRef={editorContentRef} />
     </div>
   );
 };

--- a/frontend/src/pages/LevellogPage/index.tsx
+++ b/frontend/src/pages/LevellogPage/index.tsx
@@ -11,17 +11,11 @@ import QnAList from './QnAList';
 import { CONFIRM_MESSAGE } from '../../constants';
 import { useParams } from 'react-router-dom';
 import useLevellogComment from '../../hooks/Levellog/useLevellogComment';
-import Editor from '../../components/Editor/Editor';
-import { EditorForm, SubmitButton } from '../StudylogPage/styles';
 import CommentList from '../../components/Comment/CommentList';
-import { useContext } from 'react';
-import { UserContext } from '../../contexts/UserProvider';
 import CommentEditorForm from '../../components/Comment/CommentEditorForm';
 
 const LevellogPage = () => {
   const { id } = useParams<{ id: string }>();
-  const { user } = useContext(UserContext);
-  const { isLoggedIn } = user;
 
   const {
     levellog,

--- a/frontend/src/pages/StudylogPage/index.tsx
+++ b/frontend/src/pages/StudylogPage/index.tsx
@@ -104,23 +104,13 @@ const StudylogPage = () => {
   }, [accessToken, id]);
 
   /* 댓글 로직 */
-  const { comments, createComment, editComment, deleteComment } = useStudylogComment(Number(id));
-
-  const editorContentRef = useRef<any>(null);
-
-  const onSubmitComment = (event) => {
-    event.preventDefault();
-
-    const content = editorContentRef.current?.getInstance().getMarkdown() || '';
-
-    if (content.length === 0) {
-      alert(ALERT_MESSAGE.NO_CONTENT);
-      return;
-    }
-
-    createComment({ content });
-    editorContentRef.current?.getInstance().setMarkdown('');
-  };
+  const {
+    comments,
+    editorContentRef,
+    editComment,
+    deleteComment,
+    onSubmitComment,
+  } = useStudylogComment(Number(id));
 
   useBeforeunload(editorContentRef);
 

--- a/frontend/src/pages/StudylogPage/index.tsx
+++ b/frontend/src/pages/StudylogPage/index.tsx
@@ -18,7 +18,6 @@ import { ALERT_MESSAGE, CONFIRM_MESSAGE, PATH } from '../../constants';
 import CommentList from '../../components/Comment/CommentList';
 import useStudylogComment from '../../hooks/Comment/useStudylogComment';
 import useBeforeunload from '../../hooks/useBeforeunload';
-import Editor from '../../components/Editor/Editor';
 import {
   useDeleteLikeMutation,
   useDeleteScrapMutation,
@@ -26,6 +25,7 @@ import {
   usePostLikeMutation,
   usePostScrapMutation,
 } from '../../hooks/queries/studylog';
+import CommentEditorForm from '../../components/Comment/CommentEditorForm';
 
 const StudylogPage = () => {
   const { id } = useParams<{ id: string }>();
@@ -150,12 +150,7 @@ const StudylogPage = () => {
       {comments && (
         <CommentList comments={comments} editComment={editComment} deleteComment={deleteComment} />
       )}
-      {isLoggedIn && (
-        <EditorForm onSubmit={onSubmitComment}>
-          <Editor height="25rem" hasTitle={false} editorContentRef={editorContentRef} />
-          <SubmitButton>작성 완료</SubmitButton>
-        </EditorForm>
-      )}
+      <CommentEditorForm onSubmit={onSubmitComment} editorContentRef={editorContentRef} />
     </div>
   );
 };

--- a/frontend/src/pages/StudylogPage/styles.ts
+++ b/frontend/src/pages/StudylogPage/styles.ts
@@ -163,6 +163,10 @@ const SubmitButton = styled.button`
   :hover {
     background-color: ${COLOR.LIGHT_BLUE_500};
   }
+
+  :disabled {
+    background-color: ${COLOR.LIGHT_GRAY_300};
+  }
 `;
 
 export {

--- a/frontend/src/routes.js
+++ b/frontend/src/routes.js
@@ -40,22 +40,22 @@ const pageRoutes = [
     path: `${PATH.STUDYLOG}/:id/edit`,
     render: () => <EditStudylogPage />,
   },
-  // {
-  //   path: [PATH.LEVELLOG],
-  //   render: () => <LevellogListPage />,
-  // },
-  // {
-  //   path: [PATH.NEW_LEVELLOG],
-  //   render: () => <NewLevellogPage />,
-  // },
-  // {
-  //   path: [`${PATH.LEVELLOG}/:id`],
-  //   render: () => <LevellogPage />,
-  // },
-  // {
-  //   path: [`${PATH.LEVELLOG}/:id/edit`],
-  //   render: () => <EditLevellogPage />,
-  // },
+  {
+    path: [PATH.LEVELLOG],
+    render: () => <LevellogListPage />,
+  },
+  {
+    path: [PATH.NEW_LEVELLOG],
+    render: () => <NewLevellogPage />,
+  },
+  {
+    path: [`${PATH.LEVELLOG}/:id`],
+    render: () => <LevellogPage />,
+  },
+  {
+    path: [`${PATH.LEVELLOG}/:id/edit`],
+    render: () => <EditLevellogPage />,
+  },
   {
     path: [PATH.PROFILE],
     render: () => <ProfilePage menu={PROFILE_PAGE_MENU.OVERVIEW} />,


### PR DESCRIPTION
## 작업 내용

- 레벨로그 댓글 기능을 구현했습니다.
- 로그인 하지 않아도 댓글을 보여줍니다. 댓글 작성 버튼을 제한합니다.
<img width="888" alt="image" src="https://user-images.githubusercontent.com/24906022/190536649-f923783e-4494-40fe-bf38-058ea49b129a.png">
   ToastEditor에서 form diable 기능이 없어서, 버튼을 제한하는 식으로 표현했습니다.

## 공유 사항

학습로그의 댓글과, 레벨로그의 댓글이 있습니다. 현재 100% 똑같은 비즈니스 로직이지만, flag를 이용해 추상화하기보다는 명확히 분리하는 방향을 선택했습니다. 그 이유는 다음과 같습니다.

1. 학습로그 댓글은 핵심적인 기능, 레벨로그는 신기능이고 유저 테스트가 필요한 영역입니다. 그러므로 학습로그 댓글 로직을 오염시키지 않는 선에서 작업하고 싶었습니다.
2. 레벨로그 댓글이 학습로그의 모양새와 같아진 이유는, 빠르게 개발하여 유저 테스트를 하기 위함이었습니다. 레벨로그의 기능이 검증되고 나면 충분히 다른 도메인으로 확장될 수 있을 것이라고 생각했습니다.

같은 레벨로그 스쿼드를 진행하고 있는 마르코(@wonsss), 레벨3에서 레벨로그 진행해준 후이(@kwannee) 에게 리뷰 요청합니다.

Resolves #1008