### PR TITLE
fix: 내 학습로그에서 뒤로가기를 3번해야 작동하는 문제 해결

### DIFF
--- a/frontend/src/pages/ProfilePageStudylogs/index.js
+++ b/frontend/src/pages/ProfilePageStudylogs/index.js
@@ -54,6 +54,7 @@ const ProfilePageStudylogs = () => {
   const { accessToken, username: myName } = user;
 
   const { username } = useParams();
+
   const { state } = useLocation();
 
   const [shouldInitialLoad, setShouldInitialLoad] = useState(!state);
@@ -101,8 +102,11 @@ const ProfilePageStudylogs = () => {
 
   useEffect(() => {
     const params = getFullParams();
+    const path = `${PATH.ROOT}${username}/studylogs${params && '?' + params}`;
 
-    history.push(`${PATH.ROOT}${username}/studylogs${params && '?' + params}`);
+    if (history.location.pathname !== path) {
+      history.push(path);
+    }
   }, [postQueryParams, selectedFilterDetails, username]);
 
   useEffect(() => {


### PR DESCRIPTION
## 버그 내용

내 학습로그 페이지에 들어가면 뒤로가기를 3번해야 1번 제대로 작동하는 버그

## 작업내용

history 객체의 location.pathname 속성을 활용하여 history.push 메서드가 한 번만 실행되도록 변경하였습니다.

## 이슈

내 학습로그 페이지에 접속하면 1번 렌더링 + 2번의 리렌더링이 연속적으로 (아무런 상호작용을 하지 않아도) 발생되는 근본적인 문제에 대한 해결이 추후에 필요해보입니다.

Close #828 

