### PR TITLE
feat: 로드맵을 위한 하위 컴포넌트 구현

### DIFF
--- a/frontend/.storybook/main.js
+++ b/frontend/.storybook/main.js
@@ -1,11 +1,11 @@
 module.exports = {
-  "stories": [
-    "../src/**/*.stories.mdx",
-    "../src/**/*.stories.@(js|jsx|ts|tsx)"
+  stories: ['../src/**/*.stories.mdx', '../src/**/*.stories.@(js|jsx|ts|tsx)'],
+  addons: [
+    '@storybook/addon-links',
+    '@storybook/addon-essentials',
+    '@storybook/preset-create-react-app',
   ],
-  "addons": [
-    "@storybook/addon-links",
-    "@storybook/addon-essentials",
-    "@storybook/preset-create-react-app"
-  ]
-}
+  typescript: {
+    reactDocgen: 'none',
+  },
+};

--- a/frontend/src/components/Button/ResponsiveButton.stories.js
+++ b/frontend/src/components/Button/ResponsiveButton.stories.js
@@ -1,0 +1,54 @@
+/** @jsxImportSource @emotion/react */
+
+import { css } from '@emotion/react';
+import { COLOR } from '../../enumerations/color';
+import ResponsiveButton from './ResponsiveButton';
+
+export default {
+  title: 'Component/ResponsiveButton',
+  component: ResponsiveButton,
+  argTypes: {},
+};
+
+const Template = (size) => (args) => (
+  <div
+    css={css`
+      width: ${size}px;
+    `}
+  >
+    <ResponsiveButton {...args} />
+  </div>
+);
+
+const SessionTemplate = Template(135);
+
+export const Session = SessionTemplate.bind({});
+
+Session.args = {
+  text: '프론트엔드 세션1',
+  color: 'white',
+  backgroundColor: COLOR.LIGHT_BLUE_900,
+  height: '36px',
+};
+
+const Depth1Template = Template(820);
+
+export const Depth1 = Depth1Template.bind({});
+
+Depth1.args = {
+  text: 'JavaScript',
+  color: 'white',
+  backgroundColor: COLOR.LIGHT_BLUE_800,
+  height: '50px',
+};
+
+const Depth2Template = Template(386);
+
+export const Depth2 = Depth2Template.bind({});
+
+Depth2.args = {
+  text: 'JavaScript',
+  color: 'white',
+  backgroundColor: COLOR.LIGHT_BLUE_500,
+  height: '50px',
+};

--- a/frontend/src/components/Button/ResponsiveButton.tsx
+++ b/frontend/src/components/Button/ResponsiveButton.tsx
@@ -1,0 +1,40 @@
+import { css } from '@emotion/react';
+import styled from '@emotion/styled';
+import React, { ButtonHTMLAttributes } from 'react';
+
+interface ResponsiveButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  text: string;
+  fontSize?: string;
+  color?: string;
+  backgroundColor?: string;
+  height?: string;
+}
+
+const ResponsiveButton = ({
+  text,
+  fontSize,
+  color,
+  backgroundColor,
+  height,
+}: ResponsiveButtonProps) => {
+  return (
+    <StyledResponsiveButton color={color} backgroundColor={backgroundColor} height={height}>
+      {text}
+    </StyledResponsiveButton>
+  );
+};
+
+export default ResponsiveButton;
+
+const StyledResponsiveButton = styled.button<Omit<ResponsiveButtonProps, 'text'>>`
+  width: 100%;
+  border-radius: 12px;
+  text-align: center;
+
+  ${({ fontSize, color, backgroundColor, height }) => css`
+    font-size: ${fontSize || '16px'};
+    color: ${color};
+    background-color: ${backgroundColor};
+    height: ${height || '50px'};
+  `};
+`;

--- a/frontend/src/components/Button/ResponsiveButton.tsx
+++ b/frontend/src/components/Button/ResponsiveButton.tsx
@@ -26,7 +26,9 @@ const ResponsiveButton = ({
 
 export default ResponsiveButton;
 
-const StyledResponsiveButton = styled.button<Omit<ResponsiveButtonProps, 'text'>>`
+const StyledResponsiveButton = styled.button<
+  Pick<ResponsiveButtonProps, 'fontSize' | 'color' | 'backgroundColor' | 'height'>
+>`
   width: 100%;
   border-radius: 12px;
   text-align: center;

--- a/frontend/src/components/Button/ResponsiveButton.tsx
+++ b/frontend/src/components/Button/ResponsiveButton.tsx
@@ -18,7 +18,12 @@ const ResponsiveButton = ({
   height,
 }: ResponsiveButtonProps) => {
   return (
-    <StyledResponsiveButton color={color} backgroundColor={backgroundColor} height={height}>
+    <StyledResponsiveButton
+      fontSize={fontSize}
+      color={color}
+      backgroundColor={backgroundColor}
+      height={height}
+    >
       {text}
     </StyledResponsiveButton>
   );

--- a/frontend/src/components/KeywordSection/KeywordSection.stories.js
+++ b/frontend/src/components/KeywordSection/KeywordSection.stories.js
@@ -1,0 +1,19 @@
+import KeywordSection from './KeywordSection';
+import SomeImage from '../../assets/images/background-image.png';
+
+export default {
+  title: 'Component/KeywordSection',
+  component: KeywordSection,
+  argTypes: {},
+};
+
+const Template = (args) => <KeywordSection {...args} />;
+
+export const Selected = Template.bind({});
+
+Selected.args = {
+  src: SomeImage,
+  alt: '이미지',
+  text: 'JavaScript',
+  isSelected: true,
+};

--- a/frontend/src/components/KeywordSection/KeywordSection.tsx
+++ b/frontend/src/components/KeywordSection/KeywordSection.tsx
@@ -1,0 +1,61 @@
+import styled from '@emotion/styled';
+import React, { useState } from 'react';
+import SomeImage from '../../assets/images/background-image.png';
+import { COLOR } from '../../enumerations/color';
+import LabelledImage from '../LabelledImage/LabelledImage';
+
+interface Keyword {
+  src: string;
+  alt: string;
+  text: string;
+}
+
+const keywords: Keyword[] = [
+  { src: SomeImage, alt: 'JavaScript', text: 'JavaScript' },
+  { src: SomeImage, alt: 'JavaScript', text: 'JavaScript' },
+  { src: SomeImage, alt: 'JavaScript', text: 'JavaScript' },
+  { src: SomeImage, alt: 'JavaScript', text: 'JavaScript' },
+];
+
+const KeywordSection = () => {
+  const [keywordOrder, setKeywordOrder] = useState(0);
+
+  const handleClickKeyword = (order: number) => {
+    setKeywordOrder(order);
+  };
+  return (
+    <StyledRoot>
+      {keywords.map((keyword, index) => (
+        <StyledWrapper>
+          <LabelledImage
+            {...keyword}
+            isSelected={keywordOrder === index}
+            onClick={() => setKeywordOrder(index)}
+          />
+          {index + 1 !== keywords.length && <StyledArrow />}
+        </StyledWrapper>
+      ))}
+    </StyledRoot>
+  );
+};
+
+export default KeywordSection;
+
+const StyledRoot = styled.div`
+  display: flex;
+`;
+
+const StyledArrow = styled.div`
+  width: 0;
+  height: 0;
+  border: 9px solid transparent;
+  border-top: 0;
+  border-bottom: 15px solid ${COLOR.LIGHT_BLUE_700};
+  transform: rotate(90deg);
+  margin: 0 12px;
+`;
+
+const StyledWrapper = styled.div`
+  display: flex;
+  align-items: center;
+`;

--- a/frontend/src/components/LabelledImage/LabelledImage.stories.js
+++ b/frontend/src/components/LabelledImage/LabelledImage.stories.js
@@ -1,0 +1,28 @@
+import LabelledImage from './LabelledImage';
+import SomeImage from '../../assets/images/background-image.png';
+
+export default {
+  title: 'Component/LabelledImage',
+  component: LabelledImage,
+  argTypes: {},
+};
+
+const Template = (args) => <LabelledImage {...args} />;
+
+export const Selected = Template.bind({});
+
+Selected.args = {
+  src: SomeImage,
+  alt: '이미지',
+  text: 'JavaScript',
+  isSelected: true,
+};
+
+export const UnSelected = Template.bind({});
+
+UnSelected.args = {
+  src: SomeImage,
+  alt: '이미지',
+  text: 'JavaScript',
+  isSelected: false,
+};

--- a/frontend/src/components/LabelledImage/LabelledImage.tsx
+++ b/frontend/src/components/LabelledImage/LabelledImage.tsx
@@ -1,0 +1,30 @@
+import { css } from '@emotion/react';
+import styled from '@emotion/styled';
+import React, { ImgHTMLAttributes } from 'react';
+import { COLOR } from '../../enumerations/color';
+
+interface LabelledImageProps extends ImgHTMLAttributes<HTMLImageElement> {
+  text: string;
+  isSelected?: boolean;
+}
+
+const LabelledImage = ({ src, alt, text, isSelected }: LabelledImageProps) => {
+  return (
+    <StyledRoot isSelected={isSelected}>
+      <img src={src} alt={alt} width="100px" height="100px" />
+      <h3>{text}</h3>
+    </StyledRoot>
+  );
+};
+
+export default LabelledImage;
+
+const StyledRoot = styled.div<Pick<LabelledImageProps, 'isSelected'>>`
+  text-align: center;
+  opacity: ${({ isSelected }) => (isSelected ? 1 : 0.6)};
+
+  & > img {
+    border-radius: 50%;
+    border: ${({ isSelected }) => isSelected && `4px solid ${COLOR.LIGHT_BLUE_700}`};
+  }
+`;


### PR DESCRIPTION
- API 명세가 도출되기 전까지, storybook을 활용하여 하위 컴포넌트를 구성해놓습니다.

**ResponsiveButton**
아무래도 기존 Button 컴포넌트로는 재사용이 불가능하고, 각 size마다 rem을 명시해놓아서, 반응형이 어려울 것 같았습니다. 이 컴포넌트는 무조건 width 100%를 가집니다. 상위에서 ResponsiveButton을 감싸서 반응형 크기를 조절합니다. 
이름은... Button이 이미 있어서 다르게 지어보았습니다만, 괜찮은지 리뷰 부탁드립니다.
<img width="205" alt="image" src="https://user-images.githubusercontent.com/24906022/193592547-72024746-ae78-4f5e-95f5-196d6867e300.png">

**LaballedImage**
<img width="174" alt="image" src="https://user-images.githubusercontent.com/24906022/193592621-8dd88b6e-2a65-4bf1-a365-df39aff7c071.png">

**KeywordSection**
<img width="598" alt="image" src="https://user-images.githubusercontent.com/24906022/193592675-9feafa79-dea1-4753-8566-f82df66e58ab.png">

Resolves #1046 