### PR TITLE
feat: 로드맵을 위한 하위 컴포넌트 구현(sidesheet modal)

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -41,5 +41,7 @@
   <body>
     <div id="root"></div>
     <div id="snackbar"></div>
+    <div id="backdrop-root"></div>
+    <div id="overlay-root"></div>
   </body>
 </html>

--- a/frontend/src/components/@shared/SideSheet/SideSheet.stories.tsx
+++ b/frontend/src/components/@shared/SideSheet/SideSheet.stories.tsx
@@ -1,0 +1,20 @@
+import { SideSheet, SideSheetProps } from './SideSheet';
+
+const backdropRoot = document.createElement('div');
+backdropRoot.setAttribute('id', 'backdrop-root');
+document.body.append(backdropRoot);
+
+const modalRoot = document.createElement('div');
+modalRoot.setAttribute('id', 'overlay-root');
+document.body.append(modalRoot);
+
+export default {
+  title: 'Component/SideSheet',
+  component: SideSheet,
+};
+
+export const DefaultSideSheet = (args: SideSheetProps) => <SideSheet {...args} />;
+
+DefaultSideSheet.args = {
+  children: '테스트',
+};

--- a/frontend/src/components/@shared/SideSheet/SideSheet.style.ts
+++ b/frontend/src/components/@shared/SideSheet/SideSheet.style.ts
@@ -1,0 +1,42 @@
+import styled from '@emotion/styled';
+import { css, keyframes } from '@emotion/react';
+import { SideSheetProps } from './SideSheet';
+
+export type SideSheetContentProps = Pick<SideSheetProps, 'width'>;
+
+const slide = keyframes`
+  from{
+    transform: translateX(100%);
+  }
+  to {
+    transform: translateX(0);
+  }
+`;
+
+export const SideSheetContent = styled.div<SideSheetContentProps>`
+  ${({ width }) => css`
+    position: fixed;
+    top: 0;
+    right: 0;
+    display: flex;
+    justify-content: center;
+    flex-wrap: wrap;
+    width: ${width ?? '500px'};
+    height: 100%;
+    overflow-y: auto;
+    padding: 34px 0;
+    background-color: #fff;
+    z-index: 101;
+    animation: 0.25s ease-in forwards ${slide};
+  `}
+`;
+
+export const Backdrop = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100vh;
+  background-color: rgba(0, 0, 0, 0.4);
+  z-index: 100;
+`;

--- a/frontend/src/components/@shared/SideSheet/SideSheet.tsx
+++ b/frontend/src/components/@shared/SideSheet/SideSheet.tsx
@@ -1,0 +1,27 @@
+import { PropsWithChildren } from 'react';
+import ReactDOM from 'react-dom';
+import { Backdrop, SideSheetContent } from './SideSheet.style';
+
+export type SideSheetProps = {
+  width?: string;
+  handleCloseSideSheet(): void;
+};
+
+export const SideSheet = ({
+  children,
+  width,
+  handleCloseSideSheet,
+}: PropsWithChildren<SideSheetProps>) => {
+  return (
+    <>
+      {ReactDOM.createPortal(
+        <Backdrop onClick={handleCloseSideSheet} />,
+        document.getElementById('backdrop-root') as HTMLElement
+      )}
+      {ReactDOM.createPortal(
+        <SideSheetContent width={width}>{children}</SideSheetContent>,
+        document.getElementById('overlay-root') as HTMLElement
+      )}
+    </>
+  );
+};


### PR DESCRIPTION
close #1046 
- 로드맵을 위한 하위 컴포넌트로서 사이드시트 모달을 구현하고 해당 컴포넌트의 스토리북을 작성함

- 사용방법
```typescript
const Component = () => {
	const [isSideSheetOpen, setIsSideSheetOpen] = useState(false);
	
	const handleOpenSideSheet = () => {
		setIsSideSheetOpen(true);
	};
	
	const handleCloseSideSheet = () => {
		setIsSideSheetOpen(false);
	};
	
	return (
		<>
		    <button onClick={handleOpenSideSheet}>
		      로드맵 열기
		    </Button>
		
		    {isSideSheetOpen && (
			    <SideSheet
			      handleCloseSideSheet={handleCloseSideSheet}
			    ><넣을 컴포넌트>  
				</SideSheet>
		  	)}
		
		</>
	)
}
```