### PR TITLE
feat: 이미지 삽입 기능

### DIFF
--- a/frontend/src/components/Editor/Editor.tsx
+++ b/frontend/src/components/Editor/Editor.tsx
@@ -12,6 +12,7 @@ import { EditorStyle } from '../Introduction/Introduction.styles';
 import { EditorTitleStyle, EditorWrapperStyle } from './Editor.styles';
 import { ChangeEventHandler, MutableRefObject } from 'react';
 import { getSize } from '../../utils/styles';
+import useImage from '../../hooks/useImage';
 
 interface EditorProps {
   height: number | string;
@@ -44,6 +45,8 @@ const Editor = (props: EditorProps): JSX.Element => {
     toolbarItems = DEFAULT_TOOLBAR_ITEMS,
   } = props;
 
+  const { uploadImage } = useImage();
+
   return (
     <div css={[EditorStyle, markdownStyle, EditorWrapperStyle]}>
       {hasTitle && (
@@ -63,6 +66,9 @@ const Editor = (props: EditorProps): JSX.Element => {
           toolbarItems={toolbarItems}
           extendedAutolinks={true}
           plugins={[[codeSyntaxHighlight, { highlighter: Prism }]]}
+          hooks={{
+            addImageBlobHook: uploadImage,
+          }}
         />
       )}
     </div>

--- a/frontend/src/hooks/useImage.ts
+++ b/frontend/src/hooks/useImage.ts
@@ -9,7 +9,7 @@ const useImage = () => {
 
     try {
       const imageData = new FormData();
-      imageData.append('image', blob);
+      imageData.append('file', blob);
 
       const response = await requestImageUpload(imageData);
 

--- a/frontend/src/hooks/useImage.ts
+++ b/frontend/src/hooks/useImage.ts
@@ -1,0 +1,30 @@
+import { requestImageUpload } from '../service/requests';
+import useSnackBar from './useSnackBar';
+
+const useImage = () => {
+  const { openSnackBar } = useSnackBar();
+
+  const uploadImage = async (blob, callback) => {
+    if (blob.size > 1024 * 1024 * 10) return openSnackBar('10MB 이하의 이미지를 업로드해주세요.');
+
+    try {
+      const imageData = new FormData();
+      imageData.append('image', blob);
+
+      const response = await requestImageUpload(imageData);
+
+      if (!response.ok) throw new Error('이미지 업로드에 실패하였습니다');
+
+      const { imageUrl } = await response.json();
+
+      callback(imageUrl, blob.name);
+    } catch (error) {
+      console.error(error);
+      openSnackBar('해당 이미지를 업로드 할 수 없습니다.');
+    }
+  };
+
+  return { uploadImage };
+};
+
+export default useImage;

--- a/frontend/src/service/requests.js
+++ b/frontend/src/service/requests.js
@@ -291,3 +291,9 @@ export const requestGetMatchedStudylogs = ({ accessToken, startDate, endDate }) 
       Authorization: `Bearer ${accessToken}`,
     },
   });
+
+export const requestImageUpload = (formData) =>
+  fetch(`${BASE_URL}/image`, {
+    method: 'POST',
+    body: formData,
+  });

--- a/frontend/src/service/requests.js
+++ b/frontend/src/service/requests.js
@@ -293,7 +293,7 @@ export const requestGetMatchedStudylogs = ({ accessToken, startDate, endDate }) 
   });
 
 export const requestImageUpload = (formData) =>
-  fetch(`${BASE_URL}/image`, {
+  fetch(`${BASE_URL}/images`, {
     method: 'POST',
     body: formData,
   });


### PR DESCRIPTION
구현 기능
> 프롤로그 작성시 사진을 넣는 경우 base64로 인코딩되어 url이 길어지는 문제 발생
- 사진이 업로드 되면 해당 파일을 /images로 전송한 후 서버에서 s3에 등록후 해당 url을 받아 이를 렌더링하는 형식으로 변경

주의 사항
- 현재 로컬에서 테스트가 불가한 상황이라 데브에서 테스트를 위해 PR작성합니다.