### PR TITLE
feat: 임시 저장 기능 구현

### DIFF
--- a/frontend/src/apis/studylogs.ts
+++ b/frontend/src/apis/studylogs.ts
@@ -2,12 +2,12 @@ import axios, { AxiosPromise, AxiosRequestConfig, AxiosResponse } from 'axios';
 import { BASE_URL } from '../configs/environment';
 import {
   Mission,
-  SavedStudyLog,
+  TempSavedStudyLog,
   Session,
   Studylog,
   StudylogForm,
   Tag,
-  SavedStudyLogForm,
+  TempSavedStudyLogForm,
 } from '../models/Studylogs';
 
 export const requestGetPopularStudylogs = ({ accessToken }: { accessToken?: string }) => {
@@ -135,17 +135,18 @@ export const requestEditStudylog = ({
   httpRequester.put(`/studylogs/${id}`, data, getAuthConfig(accessToken));
 
 /** 임시 저장 **/
-export const requestGetSavedStudylog = ({
+export const requestGetTempSavedStudylog = ({
   accessToken,
 }: {
   accessToken: string;
-}): AxiosPromise<SavedStudyLog> => httpRequester.get('/studylogs/temp', getAuthConfig(accessToken));
+}): AxiosPromise<TempSavedStudyLog> =>
+  httpRequester.get('/studylogs/temp', getAuthConfig(accessToken));
 
-export const requestPostSavedStudylog = ({
+export const requestPostTempSavedStudylog = ({
   accessToken,
   data,
 }: {
   accessToken: string;
-  data: SavedStudyLogForm;
+  data: TempSavedStudyLogForm;
 }): AxiosPromise<AxiosResponse<null>> =>
   httpRequester.put('/studylogs/temp', data, getAuthConfig(accessToken));

--- a/frontend/src/apis/studylogs.ts
+++ b/frontend/src/apis/studylogs.ts
@@ -1,6 +1,14 @@
 import axios, { AxiosPromise, AxiosRequestConfig, AxiosResponse } from 'axios';
 import { BASE_URL } from '../configs/environment';
-import { Mission, Session, Studylog, StudylogForm, Tag } from '../models/Studylogs';
+import {
+  Mission,
+  SavedStudyLog,
+  Session,
+  Studylog,
+  StudylogForm,
+  Tag,
+  SavedStudyLogForm,
+} from '../models/Studylogs';
 
 export const requestGetPopularStudylogs = ({ accessToken }: { accessToken?: string }) => {
   if (accessToken) {
@@ -125,3 +133,19 @@ export const requestEditStudylog = ({
   data: StudylogForm;
 }): AxiosPromise<AxiosResponse<null>> =>
   httpRequester.put(`/studylogs/${id}`, data, getAuthConfig(accessToken));
+
+/** 임시 저장 **/
+export const requestGetSavedStudylog = ({
+  accessToken,
+}: {
+  accessToken: string;
+}): AxiosPromise<SavedStudyLog> => httpRequester.get('/studylogs/temp', getAuthConfig(accessToken));
+
+export const requestPostSavedStudylog = ({
+  accessToken,
+  data,
+}: {
+  accessToken: string;
+  data: SavedStudyLogForm;
+}): AxiosPromise<AxiosResponse<null>> =>
+  httpRequester.put('/studylogs/temp', data, getAuthConfig(accessToken));

--- a/frontend/src/apis/studylogs.ts
+++ b/frontend/src/apis/studylogs.ts
@@ -137,10 +137,9 @@ export const requestEditStudylog = ({
 
 /** 임시 저장 **/
 export const requestGetTempSavedStudylog = async () => {
-  const res = await client.get<TempSavedStudyLog>('/studylogs/temp');
-  console.log(res, 'api');
+  const { data } = await client.get<TempSavedStudyLog>('/studylogs/temp');
 
-  return res.data;
+  return data;
 };
 
 export const requestPostTempSavedStudylog = ({

--- a/frontend/src/apis/studylogs.ts
+++ b/frontend/src/apis/studylogs.ts
@@ -1,4 +1,5 @@
 import axios, { AxiosPromise, AxiosRequestConfig, AxiosResponse } from 'axios';
+import { Nullable } from '../types/utils';
 import { client } from '.';
 import { BASE_URL } from '../configs/environment';
 import {
@@ -137,16 +138,10 @@ export const requestEditStudylog = ({
 
 /** 임시 저장 **/
 export const requestGetTempSavedStudylog = async () => {
-  const { data } = await client.get<TempSavedStudyLog>('/studylogs/temp');
+  const { data } = await client.get<Nullable<TempSavedStudyLog>>('/studylogs/temp');
 
   return data;
 };
 
-export const requestPostTempSavedStudylog = ({
-  accessToken,
-  data,
-}: {
-  accessToken: string;
-  data: TempSavedStudyLogForm;
-}): AxiosPromise<AxiosResponse<null>> =>
-  httpRequester.put('/studylogs/temp', data, getAuthConfig(accessToken));
+export const requestPostTempSavedStudylog = (data: TempSavedStudyLogForm) =>
+  client.put('/studylogs/temp', data);

--- a/frontend/src/apis/studylogs.ts
+++ b/frontend/src/apis/studylogs.ts
@@ -1,4 +1,5 @@
 import axios, { AxiosPromise, AxiosRequestConfig, AxiosResponse } from 'axios';
+import { client } from '.';
 import { BASE_URL } from '../configs/environment';
 import {
   Mission,
@@ -135,12 +136,12 @@ export const requestEditStudylog = ({
   httpRequester.put(`/studylogs/${id}`, data, getAuthConfig(accessToken));
 
 /** 임시 저장 **/
-export const requestGetTempSavedStudylog = ({
-  accessToken,
-}: {
-  accessToken: string;
-}): AxiosPromise<TempSavedStudyLog> =>
-  httpRequester.get('/studylogs/temp', getAuthConfig(accessToken));
+export const requestGetTempSavedStudylog = async () => {
+  const res = await client.get<TempSavedStudyLog>('/studylogs/temp');
+  console.log(res, 'api');
+
+  return res.data;
+};
 
 export const requestPostTempSavedStudylog = ({
   accessToken,

--- a/frontend/src/components/Editor/StudylogEditor.tsx
+++ b/frontend/src/components/Editor/StudylogEditor.tsx
@@ -19,6 +19,17 @@ const SubmitButtonStyle = css`
   }
 `;
 
+const SaveButtonStyle = css`
+  width: 100%;
+  background-color: ${COLOR.LIGHT_GRAY_400};
+  padding: 1rem 0;
+  border-radius: 1.6rem;
+
+  :hover {
+    background-color: ${COLOR.LIGHT_GRAY_600};
+  }
+`;
+
 type SelectOption = { value: string; label: string };
 
 interface StudylogEditorProps {
@@ -66,12 +77,13 @@ const StudylogEditor = ({
           />
           <div
             css={[
-              getFlexStyle({ justifyContent: 'flex-end' }),
+              getFlexStyle({ justifyContent: 'flex-end', columnGap: '2rem' }),
               css`
                 margin-top: 1rem;
               `,
             ]}
           >
+            <button css={[SaveButtonStyle]}>임시 저장</button>
             <button css={[SubmitButtonStyle]}>작성 완료</button>
           </div>
         </div>

--- a/frontend/src/components/Editor/StudylogEditor.tsx
+++ b/frontend/src/components/Editor/StudylogEditor.tsx
@@ -1,7 +1,7 @@
 /** @jsxImportSource @emotion/react */
 
 import { css } from '@emotion/react';
-import { ChangeEventHandler, FormEventHandler, MutableRefObject } from 'react';
+import { ChangeEventHandler, FormEventHandler, MouseEventHandler, MutableRefObject } from 'react';
 import { COLOR } from '../../constants';
 import { Tag } from '../../models/Studylogs';
 import { getFlexStyle } from '../../styles/flex.styles';
@@ -19,7 +19,7 @@ const SubmitButtonStyle = css`
   }
 `;
 
-const SaveButtonStyle = css`
+const TempSaveButtonStyle = css`
   width: 100%;
   background-color: ${COLOR.LIGHT_GRAY_400};
   padding: 1rem 0;
@@ -47,6 +47,7 @@ interface StudylogEditorProps {
   onSelectTag: (tags: Tag[], actionMeta: { option: { label: string } }) => void;
   onSelectAbilities: (abilities: number[]) => void;
   onSubmit?: FormEventHandler<HTMLFormElement>;
+  onTempSave?: MouseEventHandler<HTMLButtonElement>;
 }
 
 const StudylogEditor = ({
@@ -63,6 +64,7 @@ const StudylogEditor = ({
   onSelectTag,
   onSelectAbilities,
   onSubmit,
+  onTempSave,
 }: StudylogEditorProps): JSX.Element => {
   return (
     <form onSubmit={onSubmit}>
@@ -83,8 +85,14 @@ const StudylogEditor = ({
               `,
             ]}
           >
-            <button css={[SaveButtonStyle]}>임시 저장</button>
-            <button css={[SubmitButtonStyle]}>작성 완료</button>
+            {onTempSave && (
+              <button type="button" css={[TempSaveButtonStyle]} onClick={onTempSave}>
+                임시 저장
+              </button>
+            )}
+            <button type="submit" css={[SubmitButtonStyle]}>
+              작성 완료
+            </button>
           </div>
         </div>
         <Sidebar

--- a/frontend/src/constants/message.js
+++ b/frontend/src/constants/message.js
@@ -5,6 +5,7 @@ const CONFIRM_MESSAGE = {
   DELETE_SCRAP: '스크랩을 취소하시겠습니까?',
   DELETE_ABILITY: '역량을 삭제하시겠습니까?',
   DELETE_LIKE: '좋아요를 취소하시겠습니까?',
+  TEMP_SAVE_STUDYLOG: '글을 저장하시겠습니까?',
   SET_DEFAULT_ABILITIES: '기본 역량 등록에 실패했습니다.',
 };
 
@@ -53,6 +54,7 @@ const ERROR_MESSAGE = {
 const SUCCESS_MESSAGE = {
   CREATE_POST: '글이 작성되었습니다.',
   EDIT_POST: '글이 수정되었습니다.',
+  TEMP_SAVE_POST: '글이 임시저장되었습니다.',
   DELETE_STUDYLOG: '글이 삭제되었습니다.',
   CREATE_ABILITY: '역량을 추가했습니다.',
   EDIT_ABILITY: '역량을 수정했습니다.',

--- a/frontend/src/constants/message.js
+++ b/frontend/src/constants/message.js
@@ -21,6 +21,7 @@ const ALERT_MESSAGE = {
   CANNOT_EDIT_OTHERS: '본인이 작성하지 않은 글은 수정할 수 없습니다.',
   NO_CONTENT: '내용을 입력하세요',
   NO_TITLE: '제목을 입력하세요',
+  NO_TITLE_OR_CONTENT: '제목이나 내용을 입력하세요',
   NO_QUESTION_AND_ANSWER: '질답을 완성해주세요',
   NO_QNA: '적어도 하나의 질답을 작성해주세요.',
 };

--- a/frontend/src/constants/reactQueryKey.js
+++ b/frontend/src/constants/reactQueryKey.js
@@ -1,5 +1,6 @@
 const REACT_QUERY_KEY = {
   STUDYLOG: 'STUDYLOG',
+  TEMP_STUDYLOG: 'TEMP_STUDYLOG',
 };
 
 export default REACT_QUERY_KEY;

--- a/frontend/src/constants/reactQueryKey.js
+++ b/frontend/src/constants/reactQueryKey.js
@@ -1,6 +1,5 @@
 const REACT_QUERY_KEY = {
   STUDYLOG: 'STUDYLOG',
-  TEMP_STUDYLOG: 'TEMP_STUDYLOG',
 };
 
 export default REACT_QUERY_KEY;

--- a/frontend/src/hooks/Studylog/useTempSavedStudylog.ts
+++ b/frontend/src/hooks/Studylog/useTempSavedStudylog.ts
@@ -1,0 +1,18 @@
+import { TempSavedStudyLogForm } from '../../models/Studylogs';
+import { useCreateTempSavedStudylog, useFetchTempSavedStudylog } from './../queries/studylog';
+
+export default function useTempSavedStudylog() {
+  const { data } = useFetchTempSavedStudylog();
+  const tempSavedStudylog = data;
+
+  const createTempSavedStudylogMutation = useCreateTempSavedStudylog();
+
+  const createTempSavedStudylog = (body: TempSavedStudyLogForm) => {
+    createTempSavedStudylogMutation.mutate(body);
+  };
+
+  return {
+    tempSavedStudylog,
+    createTempSavedStudylog,
+  };
+}

--- a/frontend/src/hooks/Studylog/useTempSavedStudylog.ts
+++ b/frontend/src/hooks/Studylog/useTempSavedStudylog.ts
@@ -2,8 +2,10 @@ import { TempSavedStudyLogForm } from '../../models/Studylogs';
 import { useCreateTempSavedStudylog, useFetchTempSavedStudylog } from './../queries/studylog';
 
 export default function useTempSavedStudylog() {
-  const { data } = useFetchTempSavedStudylog();
-  const tempSavedStudylog = data;
+  const {
+    data: tempSavedStudylog,
+    remove: removeCachedTempSavedStudylog,
+  } = useFetchTempSavedStudylog();
 
   const createTempSavedStudylogMutation = useCreateTempSavedStudylog();
 
@@ -14,5 +16,6 @@ export default function useTempSavedStudylog() {
   return {
     tempSavedStudylog,
     createTempSavedStudylog,
+    removeCachedTempSavedStudylog,
   };
 }

--- a/frontend/src/hooks/queries/studylog.ts
+++ b/frontend/src/hooks/queries/studylog.ts
@@ -80,7 +80,7 @@ export const useFetchTempSavedStudylog = () => {
   const { user } = useContext(UserContext);
   const { username } = user;
 
-  return useQuery([QUERY_KEY.tempSavedStudylog, username], () => requestGetTempSavedStudylog(), {
+  return useQuery([QUERY_KEY.tempSavedStudylog, username], requestGetTempSavedStudylog, {
     refetchOnWindowFocus: false,
     cacheTime: 0,
   });
@@ -91,7 +91,7 @@ export const useCreateTempSavedStudylog = () => {
   const { user } = useContext(UserContext);
   const { username } = user;
 
-  return useMutation((body: TempSavedStudyLogForm) => requestPostTempSavedStudylog(body), {
+  return useMutation(requestPostTempSavedStudylog, {
     onSuccess: () => {
       queryClient.invalidateQueries([QUERY_KEY.tempSavedStudylog, username]);
       alert(SUCCESS_MESSAGE.TEMP_SAVE_POST);

--- a/frontend/src/hooks/queries/studylog.ts
+++ b/frontend/src/hooks/queries/studylog.ts
@@ -1,6 +1,7 @@
+import { TempSavedStudyLogForm } from './../../models/Studylogs';
 import axios from 'axios';
 import { useContext } from 'react';
-import { useMutation, useQuery } from 'react-query';
+import { useMutation, useQuery, useQueryClient } from 'react-query';
 import { BASE_URL } from '../../configs/environment';
 import { UserContext } from '../../contexts/UserProvider';
 import { Studylog, StudyLogResponse } from '../../models/Studylogs';
@@ -22,10 +23,12 @@ import {
 } from '../../constants/message';
 import { useHistory } from 'react-router-dom';
 import { PATH } from '../../constants';
+import { requestGetTempSavedStudylog, requestPostTempSavedStudylog } from '../../apis/studylogs';
 
 const QUERY_KEY = {
   recentStudylogs: 'recentStudylogs',
   popularStudylogs: 'popularStudylogs',
+  tempSavedStudylog: 'tempSavedStudylog',
 };
 
 export const useGetRecentStudylogsQuery = () => {
@@ -69,6 +72,32 @@ export const useDeleteStudylogMutation = () => {
     },
     onError: (error: { code: number }) => {
       alert(ERROR_MESSAGE[error.code] ?? ALERT_MESSAGE.FAIL_TO_DELETE_STUDYLOG);
+    },
+  });
+};
+
+export const useFetchTempSavedStudylog = () => {
+  const { user } = useContext(UserContext);
+  const { username } = user;
+
+  return useQuery([QUERY_KEY.tempSavedStudylog, username], () => requestGetTempSavedStudylog(), {
+    refetchOnWindowFocus: false,
+    cacheTime: 0,
+  });
+};
+
+export const useCreateTempSavedStudylog = () => {
+  const queryClient = useQueryClient();
+  const { user } = useContext(UserContext);
+  const { username } = user;
+
+  return useMutation((body: TempSavedStudyLogForm) => requestPostTempSavedStudylog(body), {
+    onSuccess: () => {
+      queryClient.invalidateQueries([QUERY_KEY.tempSavedStudylog, username]);
+      alert(SUCCESS_MESSAGE.TEMP_SAVE_POST);
+    },
+    onError: () => {
+      alert(ERROR_MESSAGE.DEFAULT);
     },
   });
 };

--- a/frontend/src/hooks/queries/studylog.ts
+++ b/frontend/src/hooks/queries/studylog.ts
@@ -82,7 +82,6 @@ export const useFetchTempSavedStudylog = () => {
 
   return useQuery([QUERY_KEY.tempSavedStudylog, username], requestGetTempSavedStudylog, {
     refetchOnWindowFocus: false,
-    cacheTime: 0,
   });
 };
 

--- a/frontend/src/models/Ability.ts
+++ b/frontend/src/models/Ability.ts
@@ -1,4 +1,4 @@
-interface Ability {
+export interface Ability {
   id: number;
   name: string;
   description: string;

--- a/frontend/src/models/Studylogs.ts
+++ b/frontend/src/models/Studylogs.ts
@@ -1,3 +1,5 @@
+import { Ability } from '../models/Ability';
+
 type Role = 'UNVALIDATED' | 'CREW' | 'COACH' | 'ADMIN';
 export interface Author {
   id: number;
@@ -43,13 +45,17 @@ export interface Studylog {
   abilities: number[];
 }
 
-export type SavedStudyLog = Pick<
+export type TempSavedStudyLog = Pick<
   Studylog,
   'id' | 'author' | 'title' | 'content' | 'session' | 'mission' | 'tags'
->;
+> & {
+  abilities: Ability[];
+};
 
-export type SavedStudyLogForm = Pick<SavedStudyLog, 'title' | 'content' | 'tags'> & {
+export type TempSavedStudyLogForm = Pick<TempSavedStudyLog, 'title' | 'content' | 'tags'> & {
   missionId: number | null;
+  sessionId: number | null;
+  abilities: number[];
 };
 
 export interface StudyLogList {

--- a/frontend/src/models/Studylogs.ts
+++ b/frontend/src/models/Studylogs.ts
@@ -43,6 +43,15 @@ export interface Studylog {
   abilities: number[];
 }
 
+export type SavedStudyLog = Pick<
+  Studylog,
+  'id' | 'author' | 'title' | 'content' | 'session' | 'mission' | 'tags'
+>;
+
+export type SavedStudyLogForm = Pick<SavedStudyLog, 'title' | 'content' | 'tags'> & {
+  missionId: number | null;
+};
+
 export interface StudyLogList {
   data: Studylog[];
   totalSize: number;

--- a/frontend/src/pages/NewStudylogPage/index.tsx
+++ b/frontend/src/pages/NewStudylogPage/index.tsx
@@ -131,14 +131,8 @@ const NewStudylogPage = () => {
   const onTempSaveStudylog = () => {
     const content = editorContentRef.current?.getInstance().getMarkdown() || '';
 
-    if (studylogContent.title.length === 0) {
-      alert(ALERT_MESSAGE.NO_TITLE);
-
-      return;
-    }
-
-    if (content.length === 0) {
-      alert(ALERT_MESSAGE.NO_CONTENT);
+    if (studylogContent.title.length === 0 && content.length === 0) {
+      alert(ALERT_MESSAGE.NO_TITLE_OR_CONTENT);
 
       return;
     }

--- a/frontend/src/pages/NewStudylogPage/index.tsx
+++ b/frontend/src/pages/NewStudylogPage/index.tsx
@@ -27,7 +27,11 @@ type SelectOption = { value: string; label: string };
 const NewStudylogPage = () => {
   const history = useHistory();
   const editorContentRef = useRef<any>(null);
-  const { tempSavedStudylog, createTempSavedStudylog } = useTempSavedStudylog();
+  const {
+    tempSavedStudylog,
+    createTempSavedStudylog,
+    removeCachedTempSavedStudylog,
+  } = useTempSavedStudylog();
 
   useBeforeunload(editorContentRef);
 
@@ -115,6 +119,7 @@ const NewStudylogPage = () => {
       }),
     {
       onSuccess: async () => {
+        removeCachedTempSavedStudylog();
         alert(SUCCESS_MESSAGE.CREATE_POST);
         history.push(PATH.STUDYLOG);
       },

--- a/frontend/src/pages/NewStudylogPage/index.tsx
+++ b/frontend/src/pages/NewStudylogPage/index.tsx
@@ -2,20 +2,26 @@
 
 import { css } from '@emotion/react';
 
-import { useState, ChangeEventHandler, FormEventHandler, useRef } from 'react';
+import { useState, ChangeEventHandler, FormEventHandler, useRef, useEffect } from 'react';
 import { MainContentStyle } from '../../PageRouter';
 
 import { ERROR_MESSAGE, ALERT_MESSAGE, PATH } from '../../constants';
 
-import { StudylogForm } from '../../models/Studylogs';
-import { useMutation } from 'react-query';
+import { StudylogForm, SavedStudyLogForm, SavedStudyLog } from '../../models/Studylogs';
+import { useMutation, useQuery, UseQueryResult } from 'react-query';
 import LOCAL_STORAGE_KEY from '../../constants/localStorage';
 import { SUCCESS_MESSAGE } from '../../constants/message';
 import { useHistory } from 'react-router-dom';
-import { requestPostStudylog } from '../../apis/studylogs';
+import {
+  requestPostSavedStudylog,
+  requestPostStudylog,
+  requestGetSavedStudylog,
+} from '../../apis/studylogs';
 import StudylogEditor from '../../components/Editor/StudylogEditor';
 import useBeforeunload from '../../hooks/useBeforeunload';
 import { ResponseError } from '../../apis/studylogs';
+import { AxiosError, AxiosResponse } from 'axios';
+import REACT_QUERY_KEY from '../../constants/reactQueryKey';
 
 interface NewStudylogForm extends StudylogForm {
   abilities: number[];
@@ -25,7 +31,6 @@ type SelectOption = { value: string; label: string };
 
 const NewStudylogPage = () => {
   const history = useHistory();
-
   const editorContentRef = useRef<any>(null);
 
   useBeforeunload(editorContentRef);
@@ -38,6 +43,29 @@ const NewStudylogPage = () => {
     tags: [],
     abilities: [],
   });
+
+  const fetchTempSavedStudylogRequest: UseQueryResult<
+    AxiosResponse<SavedStudyLog>,
+    AxiosError
+  > = useQuery(
+    [REACT_QUERY_KEY.TEMP_STUDYLOG],
+    () =>
+      requestGetSavedStudylog({
+        accessToken: localStorage.getItem(LOCAL_STORAGE_KEY.ACCESS_TOKEN) as string,
+      }),
+    {
+      onSuccess: ({ data }) => {
+        setStudylogContent({
+          title: data.title,
+          content: data.content,
+          missionId: data.mission?.id || null,
+          sessionId: data.session?.id || null,
+          tags: data.tags,
+          abilities: [],
+        });
+      },
+    }
+  );
 
   const onSelectAbilities = (abilities: number[]) => {
     setStudylogContent({ ...studylogContent, abilities });
@@ -72,11 +100,13 @@ const NewStudylogPage = () => {
 
     if (studylogContent.title.length === 0) {
       alert(ALERT_MESSAGE.NO_TITLE);
+
       return;
     }
 
     if (content.length === 0) {
       alert(ALERT_MESSAGE.NO_CONTENT);
+
       return;
     }
 
@@ -85,6 +115,32 @@ const NewStudylogPage = () => {
       ...studylogContent,
       content,
     });
+  };
+
+  const onTempSaveStudylog = () => {
+    const content = editorContentRef.current?.getInstance().getMarkdown() || '';
+
+    if (studylogContent.title.length === 0) {
+      alert(ALERT_MESSAGE.NO_TITLE);
+
+      return;
+    }
+
+    if (content.length === 0) {
+      alert(ALERT_MESSAGE.NO_CONTENT);
+
+      return;
+    }
+
+    // TODO: 변수명
+    if (window.confirm('저장하시겠습니까?')) {
+      tempSaveStudylogRequest({
+        title: studylogContent.title,
+        missionId: studylogContent.missionId,
+        tags: studylogContent.tags,
+        content,
+      });
+    }
   };
 
   const { mutate: createStudylogRequest } = useMutation(
@@ -104,6 +160,21 @@ const NewStudylogPage = () => {
     }
   );
 
+  const { mutate: tempSaveStudylogRequest } = useMutation(
+    (data: SavedStudyLogForm) =>
+      requestPostSavedStudylog({
+        accessToken: localStorage.getItem(LOCAL_STORAGE_KEY.ACCESS_TOKEN) as string,
+        data,
+      }),
+    {
+      onSuccess: () => {
+        console.log('success');
+      },
+    }
+  );
+
+  console.log(fetchTempSavedStudylogRequest);
+
   return (
     <div
       css={[
@@ -116,7 +187,7 @@ const NewStudylogPage = () => {
       <StudylogEditor
         title={studylogContent.title}
         contentRef={editorContentRef}
-        content={''}
+        content={studylogContent.content}
         selectedMissionId={studylogContent.missionId}
         selectedSessionId={studylogContent.sessionId}
         selectedTags={studylogContent.tags}
@@ -127,6 +198,7 @@ const NewStudylogPage = () => {
         onSelectTag={onSelectTag}
         onSelectAbilities={onSelectAbilities}
         onSubmit={onCreateStudylog}
+        onTempSave={onTempSaveStudylog}
       />
     </div>
   );

--- a/frontend/src/pages/NewStudylogPage/index.tsx
+++ b/frontend/src/pages/NewStudylogPage/index.tsx
@@ -2,27 +2,21 @@
 
 import { css } from '@emotion/react';
 
-import { useState, ChangeEventHandler, FormEventHandler, useRef, useContext } from 'react';
+import { useState, ChangeEventHandler, FormEventHandler, useRef, useEffect } from 'react';
 import { MainContentStyle } from '../../PageRouter';
 
 import { ERROR_MESSAGE, ALERT_MESSAGE, PATH } from '../../constants';
 
-import { StudylogForm, TempSavedStudyLogForm, TempSavedStudyLog } from '../../models/Studylogs';
-import { useMutation, useQuery, UseQueryResult } from 'react-query';
+import { StudylogForm } from '../../models/Studylogs';
+import { useMutation } from 'react-query';
 import LOCAL_STORAGE_KEY from '../../constants/localStorage';
 import { CONFIRM_MESSAGE, SUCCESS_MESSAGE } from '../../constants/message';
 import { useHistory } from 'react-router-dom';
-import {
-  requestPostTempSavedStudylog,
-  requestPostStudylog,
-  requestGetTempSavedStudylog,
-} from '../../apis/studylogs';
+import { requestPostStudylog } from '../../apis/studylogs';
 import StudylogEditor from '../../components/Editor/StudylogEditor';
 import useBeforeunload from '../../hooks/useBeforeunload';
 import { ResponseError } from '../../apis/studylogs';
-import { AxiosError, AxiosResponse } from 'axios';
-import REACT_QUERY_KEY from '../../constants/reactQueryKey';
-import { UserContext } from '../../contexts/UserProvider';
+import useTempSavedStudylog from '../../hooks/Studylog/useTempSavedStudylog';
 
 interface NewStudylogForm extends StudylogForm {
   abilities: number[];
@@ -33,8 +27,7 @@ type SelectOption = { value: string; label: string };
 const NewStudylogPage = () => {
   const history = useHistory();
   const editorContentRef = useRef<any>(null);
-  const { user } = useContext(UserContext);
-  const { username } = user;
+  const { tempSavedStudylog, createTempSavedStudylog } = useTempSavedStudylog();
 
   useBeforeunload(editorContentRef);
 
@@ -46,37 +39,6 @@ const NewStudylogPage = () => {
     tags: [],
     abilities: [],
   });
-
-  const fetchTempSavedStudylogRequest: UseQueryResult<
-    AxiosResponse<TempSavedStudyLog>,
-    AxiosError
-  > = useQuery(
-    [REACT_QUERY_KEY.TEMP_STUDYLOG, username],
-    () =>
-      requestGetTempSavedStudylog({
-        accessToken: localStorage.getItem(LOCAL_STORAGE_KEY.ACCESS_TOKEN) as string,
-      }),
-    {
-      refetchOnWindowFocus: false,
-      onSuccess: ({ data }) => {
-        const isTempSavedStudylogExist = Object.keys(data).some((key) => data[key] !== null);
-        if (isTempSavedStudylogExist) {
-          setStudylogContent({
-            title: data.title,
-            content: data.content,
-            missionId: data.mission?.id ?? null,
-            sessionId: data.session?.id ?? null,
-            tags: data.tags,
-            abilities: data.abilities.map(({ id }) => id),
-          });
-
-          return;
-        }
-
-        setStudylogContent({ ...studylogContent, content: '' });
-      },
-    }
-  );
 
   const onSelectAbilities = (abilities: number[]) => {
     setStudylogContent({ ...studylogContent, abilities });
@@ -138,7 +100,7 @@ const NewStudylogPage = () => {
     }
 
     if (window.confirm(CONFIRM_MESSAGE.TEMP_SAVE_STUDYLOG)) {
-      tempSaveStudylogRequest({
+      createTempSavedStudylog({
         ...studylogContent,
         content,
       });
@@ -162,21 +124,28 @@ const NewStudylogPage = () => {
     }
   );
 
-  const { mutate: tempSaveStudylogRequest } = useMutation(
-    (data: TempSavedStudyLogForm) =>
-      requestPostTempSavedStudylog({
-        accessToken: localStorage.getItem(LOCAL_STORAGE_KEY.ACCESS_TOKEN) as string,
-        data,
-      }),
-    {
-      onSuccess: () => {
-        alert(SUCCESS_MESSAGE.TEMP_SAVE_POST);
-      },
-      onError: () => {
-        alert(ERROR_MESSAGE.DEFAULT);
-      },
+  useEffect(() => {
+    if (tempSavedStudylog) {
+      const isTempSavedStudylogExist = Object.entries(tempSavedStudylog).some(
+        ([_, value]) => value !== null
+      );
+
+      if (isTempSavedStudylogExist) {
+        setStudylogContent({
+          title: tempSavedStudylog.title ?? '',
+          content: tempSavedStudylog.content,
+          missionId: tempSavedStudylog.mission?.id ?? null,
+          sessionId: tempSavedStudylog.session?.id ?? null,
+          tags: tempSavedStudylog.tags ?? [],
+          abilities: tempSavedStudylog.abilities?.map(({ id }) => id) ?? [],
+        });
+
+        return;
+      }
+
+      setStudylogContent({ ...studylogContent, content: '' });
     }
-  );
+  }, [tempSavedStudylog]);
 
   return (
     <div

--- a/frontend/src/pages/NewStudylogPage/index.tsx
+++ b/frontend/src/pages/NewStudylogPage/index.tsx
@@ -64,8 +64,8 @@ const NewStudylogPage = () => {
           setStudylogContent({
             title: data.title,
             content: data.content,
-            missionId: data.mission?.id || null,
-            sessionId: data.session?.id || null,
+            missionId: data.mission?.id ?? null,
+            sessionId: data.session?.id ?? null,
             tags: data.tags,
             abilities: data.abilities.map(({ id }) => id),
           });

--- a/frontend/src/pages/NewStudylogPage/index.tsx
+++ b/frontend/src/pages/NewStudylogPage/index.tsx
@@ -10,7 +10,7 @@ import { ERROR_MESSAGE, ALERT_MESSAGE, PATH } from '../../constants';
 import { StudylogForm, TempSavedStudyLogForm, TempSavedStudyLog } from '../../models/Studylogs';
 import { useMutation, useQuery, UseQueryResult } from 'react-query';
 import LOCAL_STORAGE_KEY from '../../constants/localStorage';
-import { SUCCESS_MESSAGE } from '../../constants/message';
+import { CONFIRM_MESSAGE, SUCCESS_MESSAGE } from '../../constants/message';
 import { useHistory } from 'react-router-dom';
 import {
   requestPostTempSavedStudylog,
@@ -69,7 +69,11 @@ const NewStudylogPage = () => {
             tags: data.tags,
             abilities: data.abilities.map(({ id }) => id),
           });
+
+          return;
         }
+
+        setStudylogContent({ ...studylogContent, content: '' });
       },
     }
   );
@@ -139,8 +143,7 @@ const NewStudylogPage = () => {
       return;
     }
 
-    // TODO: 변수명
-    if (window.confirm('저장하시겠습니까?')) {
+    if (window.confirm(CONFIRM_MESSAGE.TEMP_SAVE_STUDYLOG)) {
       tempSaveStudylogRequest({
         ...studylogContent,
         content,
@@ -173,11 +176,10 @@ const NewStudylogPage = () => {
       }),
     {
       onSuccess: () => {
-        alert('글이 임시저장되었습니다.');
-        console.log('success');
+        alert(SUCCESS_MESSAGE.TEMP_SAVE_POST);
       },
       onError: () => {
-        alert('현재 글을 임시 저장할 수 없습니다.');
+        alert(ERROR_MESSAGE.DEFAULT);
       },
     }
   );

--- a/frontend/src/types/utils.ts
+++ b/frontend/src/types/utils.ts
@@ -1,3 +1,4 @@
 type ValueOf<T> = T[keyof T];
+type Nullable<T> = { [P in keyof T]: T[P] | null };
 
-export type { ValueOf };
+export type { ValueOf, Nullable };


### PR DESCRIPTION
## 작업 내용

- 글 작성시 임시 저장 기능을 구현했습니다.


### 새로운 글 작성시 임시 저장 버튼 클릭했을 때

<img src="https://user-images.githubusercontent.com/64825713/195762468-066c7527-7af0-4f63-94d8-1d2b4436e1f8.png" width="500px" />

### 임시 저장된 글이 있을 경우, 새로운 글 작성시 해당 내용 불러온 상황
<img src="https://user-images.githubusercontent.com/64825713/195762488-059fb1e9-6bd8-4203-a317-7c7176bc2d15.png" width="500px" />

## 궁금한 점

- 임시저장한 글을 불러오는 함수는 아래와 같습니다. useQuery를 사용하여 onSuccess일 때, editor에 들어가는 내용들을 업데이트해주고 있습니다. 아래의 방법에 대해서 어떻게 생각하시는 지 궁금합니다!!


```typescript

const fetchTempSavedStudylogRequest: UseQueryResult<
    AxiosResponse<TempSavedStudyLog>,
    AxiosError
  > = useQuery(
    [REACT_QUERY_KEY.TEMP_STUDYLOG, username],
    () =>
      requestGetTempSavedStudylog({
        accessToken: localStorage.getItem(LOCAL_STORAGE_KEY.ACCESS_TOKEN) as string,
      }),
    {
      refetchOnWindowFocus: false,
      onSuccess: ({ data }) => {}
  );

```