### PR TITLE
feat: 로드맵 Mock API 구현

### DIFF
--- a/backend/src/main/java/wooteco/prolog/roadmap/application/dto/KeywordCreateRequest.java
+++ b/backend/src/main/java/wooteco/prolog/roadmap/application/dto/KeywordCreateRequest.java
@@ -1,0 +1,25 @@
+package wooteco.prolog.roadmap.application.dto;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class KeywordCreateRequest {
+
+    private String name;
+    private String description;
+    private int order;
+    private int importance;
+    private Long parentKeywordId;
+
+    public KeywordCreateRequest(final String name, final String description, final int order,
+                                final int importance, final Long parentKeywordId) {
+        this.name = name;
+        this.description = description;
+        this.order = order;
+        this.importance = importance;
+        this.parentKeywordId = parentKeywordId;
+    }
+}

--- a/backend/src/main/java/wooteco/prolog/roadmap/application/dto/KeywordResponse.java
+++ b/backend/src/main/java/wooteco/prolog/roadmap/application/dto/KeywordResponse.java
@@ -1,0 +1,32 @@
+package wooteco.prolog.roadmap.application.dto;
+
+import java.util.HashSet;
+import java.util.Set;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class KeywordResponse {
+
+    private Long keywordId;
+    private String name;
+    private String description;
+    private int order;
+    private int importance;
+    private Long parentKeywordId;
+    private Set<KeywordResponse> childrenKeywords;
+
+    public KeywordResponse(final Long keywordId, final String name, final String description, final int order,
+                           final int importance, final Long parentKeywordId,
+                           final Set<KeywordResponse> childrenKeywords) {
+        this.keywordId = keywordId;
+        this.name = name;
+        this.description = description;
+        this.order = order;
+        this.importance = importance;
+        this.parentKeywordId = parentKeywordId;
+        this.childrenKeywords = childrenKeywords;
+    }
+}

--- a/backend/src/main/java/wooteco/prolog/roadmap/application/dto/KeywordUpdateRequest.java
+++ b/backend/src/main/java/wooteco/prolog/roadmap/application/dto/KeywordUpdateRequest.java
@@ -1,0 +1,25 @@
+package wooteco.prolog.roadmap.application.dto;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class KeywordUpdateRequest {
+
+    private String name;
+    private String description;
+    private int order;
+    private int importance;
+    private Long parentKeywordId;
+
+    public KeywordUpdateRequest(final String name, final String description, final int order,
+                                final int importance, final Long parentKeywordId) {
+        this.name = name;
+        this.description = description;
+        this.order = order;
+        this.importance = importance;
+        this.parentKeywordId = parentKeywordId;
+    }
+}

--- a/backend/src/main/java/wooteco/prolog/roadmap/application/dto/KeywordsResponse.java
+++ b/backend/src/main/java/wooteco/prolog/roadmap/application/dto/KeywordsResponse.java
@@ -1,0 +1,18 @@
+package wooteco.prolog.roadmap.application.dto;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class KeywordsResponse {
+
+    private List<KeywordResponse> data;
+
+    public KeywordsResponse(final List<KeywordResponse> data) {
+        this.data = data;
+    }
+}

--- a/backend/src/main/java/wooteco/prolog/roadmap/application/dto/QuizRequest.java
+++ b/backend/src/main/java/wooteco/prolog/roadmap/application/dto/QuizRequest.java
@@ -1,0 +1,13 @@
+package wooteco.prolog.roadmap.application.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class QuizRequest {
+
+    private String question;
+}

--- a/backend/src/main/java/wooteco/prolog/roadmap/application/dto/QuizResponse.java
+++ b/backend/src/main/java/wooteco/prolog/roadmap/application/dto/QuizResponse.java
@@ -1,0 +1,19 @@
+package wooteco.prolog.roadmap.application.dto;
+
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class QuizResponse {
+
+    private Long quizId;
+    private String question;
+
+    public QuizResponse(Long quizId, String question) {
+        this.quizId = quizId;
+        this.question = question;
+    }
+}

--- a/backend/src/main/java/wooteco/prolog/roadmap/application/dto/QuizzesResponse.java
+++ b/backend/src/main/java/wooteco/prolog/roadmap/application/dto/QuizzesResponse.java
@@ -1,0 +1,22 @@
+package wooteco.prolog.roadmap.application.dto;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class QuizzesResponse {
+
+    private Long keywordId;
+
+    private List<QuizResponse> data;
+
+    public QuizzesResponse(Long keywordId,
+                           List<QuizResponse> data) {
+        this.keywordId = keywordId;
+        this.data = data;
+    }
+}

--- a/backend/src/main/java/wooteco/prolog/roadmap/ui/KeywordController.java
+++ b/backend/src/main/java/wooteco/prolog/roadmap/ui/KeywordController.java
@@ -1,0 +1,172 @@
+package wooteco.prolog.roadmap.ui;
+
+import java.net.URI;
+import java.util.Arrays;
+import java.util.HashSet;
+import org.elasticsearch.common.collect.List;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import wooteco.prolog.roadmap.application.dto.KeywordCreateRequest;
+import wooteco.prolog.roadmap.application.dto.KeywordResponse;
+import wooteco.prolog.roadmap.application.dto.KeywordUpdateRequest;
+import wooteco.prolog.roadmap.application.dto.KeywordsResponse;
+
+@RestController
+@RequestMapping("/sessions")
+public class KeywordController {
+
+    @PostMapping("/{sessionId}/keywords")
+    public ResponseEntity<Void> createKeyword(@PathVariable Long sessionId,
+                                              @RequestBody KeywordCreateRequest createRequest) {
+        return ResponseEntity.created(URI.create("/sessions/" + sessionId + "/keywords/" + 1L)).build();
+    }
+
+    @GetMapping("/{sessionId}/keywords/{keywordId}")
+    public ResponseEntity<KeywordResponse> findKeyword(@PathVariable Long sessionId,
+                                                       @PathVariable Long keywordId) {
+        return ResponseEntity.ok(keywordResponse());
+    }
+
+    private KeywordResponse keywordResponse() {
+        return new KeywordResponse(
+                2L,
+                "SRP",
+                "단일 책임 원칙입니다.",
+                1,
+                4,
+                1L,
+                null
+        );
+    }
+
+    @PutMapping("/{sessionId}/keywords/{keywordId}")
+    public ResponseEntity<Void> updateKeyword(@PathVariable Long sessionId,
+                                              @PathVariable Long keywordId,
+                                              @RequestBody KeywordUpdateRequest updateRequest) {
+        return ResponseEntity.noContent().build();
+    }
+
+    @DeleteMapping("/{sessionId}/keywords/{keywordId}")
+    public ResponseEntity<Void> deleteKeyword(@PathVariable Long sessionId,
+                                              @PathVariable Long keywordId) {
+        return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping("/{sessionId}/keywords")
+    public ResponseEntity<KeywordsResponse> findSessionIncludeRootKeywords(@PathVariable Long sessionId) {
+        return ResponseEntity.ok(keywordsResponse());
+    }
+
+    private KeywordsResponse keywordsResponse() {
+        return new KeywordsResponse(List.of(
+                new KeywordResponse(
+                        1L,
+                        "자바",
+                        "자바입니다.",
+                        1,
+                        5,
+                        null,
+                        null
+                ),
+                new KeywordResponse(
+                        2L,
+                        "스프링",
+                        "스프링입니다.",
+                        1,
+                        4,
+                        null,
+                        null
+                )
+        ));
+    }
+
+    @GetMapping("/{sessionId}/keywords/{keywordId}/children")
+    public ResponseEntity<KeywordResponse> find(@PathVariable Long sessionId,
+                                                @PathVariable Long keywordId) {
+        return ResponseEntity.ok(keywordResponseJava());
+    }
+
+    private KeywordResponse keywordResponseJava() {
+        return new KeywordResponse(
+                1L,
+                "자바",
+                "자바입니다.",
+                1,
+                5,
+                null,
+                new HashSet<>(Arrays.asList(
+                                new KeywordResponse(
+                                        2L,
+                                        "List",
+                                        "자바의 자료구조인 List입니다.",
+                                        1,
+                                        3,
+                                        1L,
+                                        keywordResponseList()
+                                ),
+                                new KeywordResponse(
+                                        3L,
+                                        "Set",
+                                        "자바의 자료구조인 Set입니다.",
+                                        2,
+                                        3,
+                                        1L,
+                                        keywordResponseSet()
+                                )
+                ))
+        );
+    }
+
+    private HashSet<KeywordResponse> keywordResponseList() {
+        return new HashSet<>(Arrays.asList(
+                new KeywordResponse(
+                        4L,
+                        "ArrayList",
+                        "자바 List의 구현체 ArrayList입니다.",
+                        1,
+                        2,
+                        2L,
+                        null
+                ),
+                new KeywordResponse(
+                        5L,
+                        "LinkedList",
+                        "자바 List의 구현체 ArrayList입니다.",
+                        2,
+                        2,
+                        2L,
+                        null
+                )
+        ));
+    }
+
+    private HashSet<KeywordResponse> keywordResponseSet() {
+        return new HashSet<>(Arrays.asList(
+                new KeywordResponse(
+                        6L,
+                        "HashSet",
+                        "자바 Set의 구현체 HashSet입니다.",
+                        1,
+                        1,
+                        3L,
+                        null
+                ),
+                new KeywordResponse(
+                        7L,
+                        "TreeSet",
+                        "자바 Set의 구현체 TreeSet입니다.",
+                        2,
+                        1,
+                        3L,
+                        null
+                )
+        ));
+    }
+}

--- a/backend/src/main/java/wooteco/prolog/roadmap/ui/QuizController.java
+++ b/backend/src/main/java/wooteco/prolog/roadmap/ui/QuizController.java
@@ -1,0 +1,51 @@
+package wooteco.prolog.roadmap.ui;
+
+import java.net.URI;
+import lombok.AllArgsConstructor;
+import org.elasticsearch.common.collect.List;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import wooteco.prolog.roadmap.application.dto.QuizRequest;
+import wooteco.prolog.roadmap.application.dto.QuizResponse;
+import wooteco.prolog.roadmap.application.dto.QuizzesResponse;
+
+@RestController
+@AllArgsConstructor
+@RequestMapping("/sessions/{sessionId}/keywords/{keywordId}/quizs")
+public class QuizController {
+
+    @PostMapping
+    public ResponseEntity<Void> create(@PathVariable Long sessionId, @PathVariable Long keywordId,
+                                       @RequestBody QuizRequest quizRequest) {
+        return ResponseEntity.created(URI.create("/sessions/" + sessionId + "/keywords/" + keywordId + "/quizs/" + 1L))
+                .build();
+    }
+
+    @GetMapping
+    public ResponseEntity<QuizzesResponse> findQuizzesByKeyword(@PathVariable Long sessionId,
+                                                                @PathVariable Long keywordId) {
+        return ResponseEntity.ok(quizzesResponse());
+    }
+
+    private QuizzesResponse quizzesResponse() {
+        return new QuizzesResponse(
+                1L,
+                List.of(new QuizResponse(1L, "자바 8 버전에 추가된 기능들은 어떤 게 있을까요?"),
+                        new QuizResponse(2L, "자바 8 버전과 11 버전의 가장 큰 차이는 무엇일까요?"),
+                        new QuizResponse(3L, "자바 String은 불변 객체인가요?"))
+        );
+    }
+
+    @DeleteMapping("/{quizId}")
+    public ResponseEntity<Void> deleteQuiz(@PathVariable Long sessionId,
+                                           @PathVariable Long keywordId,
+                                           @PathVariable Long quizId) {
+        return ResponseEntity.noContent().build();
+    }
+}


### PR DESCRIPTION
## 구현 사항
- [x] Quiz Mock API 구현
- [x] Keyword Mock API 구현

## 전달 사항
- 컨트롤러에서 단순히 Response DTO를 반환하는 방식으로 구현했습니다.
- Keyword 단건 조회, 세션별 Keyword 목록 조회 기능에도 Response에 childrenKeywords 필드가 추가됐습니다. (필드만 존재, 값은 항상 null)
- 실제 기능 merge 전 충돌 해결이 필요합니다.

close #1110 