### PR TITLE
Feature/#1236 로드맵 상위 키워드 버튼과 스크롤 바 디자인 개선

### DIFF
--- a/frontend/src/GlobalStyles.js
+++ b/frontend/src/GlobalStyles.js
@@ -29,7 +29,7 @@ const GlobalStyles = () => (
         padding: 0;
         font-size: 1.6rem;
         min-height: 100vh;
-        width: 100vw;
+        width: 100%;
         background-color: ${COLOR.LIGHT_GRAY_50};
         color: ${COLOR.DARK_GRAY_900};
         overflow-x: hidden;

--- a/frontend/src/GlobalStyles.js
+++ b/frontend/src/GlobalStyles.js
@@ -20,6 +20,8 @@ const GlobalStyles = () => (
 
       html {
         font-size: 10px;
+        scrollbar-width: thin;
+        scrollbar-color: rgba(161, 161, 161, 0.7);
       }
 
       body {
@@ -27,9 +29,26 @@ const GlobalStyles = () => (
         padding: 0;
         font-size: 1.6rem;
         min-height: 100vh;
-        width: 100%;
+        width: 100vw;
         background-color: ${COLOR.LIGHT_GRAY_50};
         color: ${COLOR.DARK_GRAY_900};
+        overflow-x: hidden;
+        overflow-y: overlay;
+      }
+
+      body::-webkit-scrollbar {
+        width: 8px;
+      }
+
+      body::-webkit-scrollbar-thumb {
+        border-radius: 4px;
+        background: rgba(161, 161, 161, 0.7);
+      }
+
+      body::-webkit-scrollbar-track,
+      body::-webkit-scrollbar-button:start:decrement,
+      body::-webkit-scrollbar-button:end:increment {
+        display: none;
       }
 
       #root {

--- a/frontend/src/components/TopKeywordList/TopKeywordList.tsx
+++ b/frontend/src/components/TopKeywordList/TopKeywordList.tsx
@@ -28,12 +28,13 @@ const TopKeywordList = ({
 
   return (
     <StyledRoot>
-      {topKeywordList?.sort(compareFn).map((keyword) => {
+      {topKeywordList?.sort(compareFn).map((keyword, index) => {
+        const isNotFirst = index > 0;
         const isSelected = selectedTopKeyword?.keywordId === keyword.keywordId;
 
         return (
           <StyledWrapper key={keyword.keywordId}>
-            <StyledArrow />
+            {isNotFirst && <StyledArrow />}
             <ResponsiveButton
               text={keyword.name}
               backgroundColor={isSelected ? COLOR.LIGHT_BLUE_900 : COLOR.LIGHT_GRAY_400}
@@ -67,9 +68,4 @@ const StyledArrow = styled.div`
 const StyledWrapper = styled.div`
   display: flex;
   align-items: center;
-
-  /* 첫 번째 화살표를 숨기는 스타일 */
-  &:first-child > :first-child {
-    display: none;
-  }
 `;

--- a/frontend/src/components/TopKeywordList/TopKeywordList.tsx
+++ b/frontend/src/components/TopKeywordList/TopKeywordList.tsx
@@ -28,18 +28,17 @@ const TopKeywordList = ({
 
   return (
     <StyledRoot>
-      {topKeywordList?.sort(compareFn).map((keyword, index) => {
-        const isNotLast = index + 1 !== topKeywordList?.length;
+      {topKeywordList?.sort(compareFn).map((keyword) => {
         const isSelected = selectedTopKeyword?.keywordId === keyword.keywordId;
 
         return (
           <StyledWrapper key={keyword.keywordId}>
+            <StyledArrow />
             <ResponsiveButton
               text={keyword.name}
               backgroundColor={isSelected ? COLOR.LIGHT_BLUE_900 : COLOR.LIGHT_GRAY_400}
               onClick={() => handleClickTopKeyword(keyword)}
-            ></ResponsiveButton>
-            {isNotLast && <StyledArrow />}
+            />
           </StyledWrapper>
         );
       })}
@@ -51,6 +50,8 @@ export default TopKeywordList;
 
 const StyledRoot = styled.div`
   display: flex;
+  flex-wrap: wrap;
+  row-gap: 12px;
 `;
 
 const StyledArrow = styled.div`
@@ -66,4 +67,9 @@ const StyledArrow = styled.div`
 const StyledWrapper = styled.div`
   display: flex;
   align-items: center;
+
+  /* 첫 번째 화살표를 숨기는 스타일 */
+  &:first-child > :first-child {
+    display: none;
+  }
 `;


### PR DESCRIPTION
## PR 재작성
#1240 PR을 다시 작성하였습니다.

## 변경 내용

로드맵 상위 키워드 버튼입니다.

|변경 전|변경 후|
|-|-|
|![image](https://user-images.githubusercontent.com/20203944/233588800-c8039540-6320-4953-a190-3b257873b2fb.png)|![image](https://user-images.githubusercontent.com/20203944/233588893-9d63c0df-3302-40b5-814b-e6627bcba2a3.png)|

스크롤 바 디자인입니다.

![image](https://user-images.githubusercontent.com/20203944/233589426-bce0b5d1-9728-443a-b365-48b99c493198.png)

크롬, Safari, Edge 에서 잘 적용된 것을 확인하였습니다. 

![image](https://user-images.githubusercontent.com/20203944/233589572-a0ea404f-4421-49dc-b4be-b346f1c35398.png)

파이어폭스의 경우 일부 CSS 적용이 불가하여 일부만 구현되었습니다. 적용이 불가한 CSS 속성은 아래와 같습니다.
```css
overflow-y: overlay;
border-radius: 4px;
```

## 관련 이슈
close #1236