### PR TITLE
Refactor/#1239 학습로그 및 로드맵에 margin css 개선

### DIFF
--- a/frontend/src/components/Items/PopularStudylogItem.tsx
+++ b/frontend/src/components/Items/PopularStudylogItem.tsx
@@ -58,7 +58,7 @@ const PopularStudylogItem = ({ item }: { item: Studylog }) => {
         </div>
 
         {/* 태그 영역 */}
-        <ul css={[TagContainerStyle]}>
+        <ul css={[TagContainerStyle]} style={{ margin: '0.5rem 0' }} >
           {tags.slice(0, 2).map(({ name: tagName, id: tagId }) => (
             <Link to={`${PATH.STUDYLOGS}?tags=${tagId}`} key={tagId}>
               <Chip title={tagName} onClick={() => {}}>

--- a/frontend/src/pages/MainPage/RecentStudylogList.tsx
+++ b/frontend/src/pages/MainPage/RecentStudylogList.tsx
@@ -15,7 +15,7 @@ import { SectionHeaderGapStyle } from './styles';
 
 const RecentStudylogList = ({ studylogs }: { studylogs: Studylog[] }) => {
   return (
-    <section>
+    <section style={{ marginTop: '3rem' }}>
       <div css={[FlexStyle, JustifyContentSpaceBtwStyle, AlignItemsCenterStyle]}>
         <h2 css={[SectionHeaderGapStyle]}>📚 최신 학습로그</h2>
         <Link to={PATH.STUDYLOGS}>{`더보기 >`}</Link>

--- a/frontend/src/pages/RoadmapPage/index.tsx
+++ b/frontend/src/pages/RoadmapPage/index.tsx
@@ -69,7 +69,7 @@ const RoadmapPage = () => {
           ) : null}
         </section>
 
-        <section>
+        <section style={{ marginBottom: '4rem' }}>
           <Styled.Title>하위 키워드 보기</Styled.Title>
           {selectedSessionId !== -1 && selectedTopKeyword ? (
             <KeywordList


### PR DESCRIPTION
### 해당 오류
[바로가기](https://github.com/woowacourse/prolog/issues/1239)

## 변경 내용
### 최신 학습로그와 인기 학습로그 거리 조절
- 변경 전
![스크린샷 2023-04-21 오후 4 07 53](https://user-images.githubusercontent.com/72205402/234556119-42a754f6-a7bc-4342-b61c-6e5534db9496.png)
- 변경 후
  <img width="529" alt="스크린샷 2023-04-26 오후 7 55 45" src="https://user-images.githubusercontent.com/72205402/234556164-a2c64b89-3eb6-4c57-b1cb-883cd631e0b0.png">

### 인기 학습로그 태그 위치 조절
- 변경 전
![스크린샷 2023-04-21 오후 4 07 29](https://user-images.githubusercontent.com/72205402/234556709-51e17263-0696-4c0e-83ff-c7916e160278.png)
- 변경 후
<img width="500" alt="스크린샷 2023-04-26 오후 7 56 56" src="https://user-images.githubusercontent.com/72205402/234556733-f5fe978c-14f9-4c0c-af5e-0d49dd7d3529.png">

### 로드맵 밑에 공백 추가
- 변경 전
![스크린샷 2023-04-21 오후 4 07 10](https://user-images.githubusercontent.com/72205402/234557267-dc31e526-6bfa-4dd9-9c2d-1187a64c2ffc.png)

- 변경 후
<img width="886" alt="스크린샷 2023-04-26 오후 8 01 25" src="https://user-images.githubusercontent.com/72205402/234557244-ed5b01da-06ba-4aaf-8bd9-c782c54ac584.png">


## 보류한 부분
![스크린샷 2023-04-21 오후 4 07 20](https://user-images.githubusercontent.com/72205402/234557558-edbad9ed-4716-45de-9cf3-ee0a86f45ec3.png)
- 페어와 상의한 결과 위치를 가운데로 바꾸면 다른 변경사항들(학습목록 글)에 영향이 가는 문제로 변경을 보류하였습니다!

- close  #1239