### PR TITLE
build: node 버전 명시 및 의존성 최신버전 사용 방지

### DIFF
--- a/.github/workflows/front-dev.yml
+++ b/.github/workflows/front-dev.yml
@@ -11,7 +11,13 @@ jobs:
       - name: Checkout Source Code
         uses: actions/checkout@v2
 
+      - name: Use node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+
       - name: Cache node_modules
+        id: cache
         uses: actions/cache@v2
         with:
           path: '**/node_modules'
@@ -20,9 +26,10 @@ jobs:
             ${{ runner.os }}-node-modules-
 
       - name: Install Dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
         run: |
           cd frontend
-          yarn
+          yarn install --frozen-lockfile
 
       - name: Build
         run: |

--- a/.github/workflows/front-prod.yml
+++ b/.github/workflows/front-prod.yml
@@ -11,7 +11,13 @@ jobs:
       - name: Checkout Source Code
         uses: actions/checkout@v2
 
+      - name: Use node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+
       - name: Cache node_modules
+        id: cache
         uses: actions/cache@v2
         with:
           path: '**/node_modules'
@@ -20,9 +26,10 @@ jobs:
             ${{ runner.os }}-node-modules-
 
       - name: Install Dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
         run: |
           cd frontend
-          yarn
+          yarn install --frozen-lockfile
 
       - name: Build
         run: |


### PR DESCRIPTION
## #️⃣연관된 이슈

Close #1271

<br><br>

## 📝작업 내용

* GitHub Actions dev, prod 배포 스크립트 수정
* node 버전 16 사용하도록 설정
* 의존성 설치 시 yarn.lock에 있는 버전 그대로 설치하도록 수정
* cache가 기능하도록 수정

![image](https://github.com/woowacourse/prolog/assets/20203944/dd3b9591-1b0d-479d-9349-b6646cd73b3d)

Workflow 성공 확인: https://github.com/woowacourse/prolog/actions/runs/4934344749

