### PR TITLE
Refactor/1270 헤어 콘텐츠 깨짐 현상 수정 및 모바일 버전 로고 변경

### DIFF
--- a/frontend/src/components/NavBar/NavBar.js
+++ b/frontend/src/components/NavBar/NavBar.js
@@ -1,8 +1,9 @@
 /** @jsxImportSource @emotion/react */
 
 import PropTypes from 'prop-types';
-import { useContext, useState } from 'react';
+import { useContext, useState, useEffect } from 'react';
 import { useHistory, Link, NavLink } from 'react-router-dom';
+import MobileLogo from '../../assets/images/woteco-logo.png';
 import LogoImage from '../../assets/images/logo.svg';
 import { PATH } from '../../constants';
 import GithubLogin from '../GithubLogin/GithubLogin';
@@ -23,7 +24,7 @@ import {
   loginButtonStyle,
 } from './NavBar.styles';
 import { UserContext } from '../../contexts/UserProvider';
-import { APP_MODE, BASE_URL, isProd } from '../../configs/environment';
+import { APP_MODE, isProd } from '../../configs/environment';
 
 const navigationConfig = [
   {
@@ -51,6 +52,9 @@ const NavBar = () => {
   const [isDropdownToggled, setDropdownToggled] = useState(false);
   const [isWritingDropdownToggled, setWritingDropdownToggled] = useState(false);
 
+  const mobile = window.matchMedia('(max-width: 420px)');
+  const [isMobile, setIsMobile] = useState(false);
+
   const goMain = () => {
     history.push(PATH.ROOT);
   };
@@ -77,6 +81,16 @@ const NavBar = () => {
     }
   };
 
+  useEffect(() => {
+    const handleResize = () => {
+        setIsMobile(mobile.matches);
+    };
+    mobile.addEventListener('change', handleResize);
+    return () => {
+        mobile.removeEventListener('change', handleResize);
+    };
+  }, [mobile]);
+
   return (
     <Container
       isDropdownToggled={isDropdownToggled || isWritingDropdownToggled}
@@ -87,13 +101,14 @@ const NavBar = () => {
     >
       <Wrapper>
         <Logo onClick={goMain} role="link" aria-label="프롤로그 홈으로 이동하기">
-          <img src={LogoImage} alt="" />
+          {isMobile ? <img src={MobileLogo} alt="" /> : <img src={LogoImage} alt="" />}
           {!isProd && <span>{logoTag}</span>}
         </Logo>
         <Menu role="menu">
           <Navigation>
             {navigationConfig.map(({ path, title }) => (
               <NavLink
+                style={{ whiteSpace: 'nowrap' }}
                 exact
                 key={path}
                 to={path}

--- a/frontend/src/components/NavBar/NavBar.js
+++ b/frontend/src/components/NavBar/NavBar.js
@@ -53,9 +53,9 @@ const NavBar = () => {
 
   const [isDropdownToggled, setDropdownToggled] = useState(false);
   const [isWritingDropdownToggled, setWritingDropdownToggled] = useState(false);
+  const [isMobile, setIsMobile] = useState(false);
 
   const mobileScreen = window.matchMedia(`(max-width: ${MOBILE_SCREEN_SIZE})`);
-  const [isMobile, setIsMobile] = useState(false);
 
   const goMain = () => {
     history.push(PATH.ROOT);

--- a/frontend/src/components/NavBar/NavBar.js
+++ b/frontend/src/components/NavBar/NavBar.js
@@ -83,11 +83,11 @@ const NavBar = () => {
 
   useEffect(() => {
     const handleResize = () => {
-        setIsMobile(mobile.matches);
+      setIsMobile(mobile.matches);
     };
     mobile.addEventListener('change', handleResize);
     return () => {
-        mobile.removeEventListener('change', handleResize);
+      mobile.removeEventListener('change', handleResize);
     };
   }, [mobile]);
 

--- a/frontend/src/components/NavBar/NavBar.js
+++ b/frontend/src/components/NavBar/NavBar.js
@@ -25,6 +25,7 @@ import {
 } from './NavBar.styles';
 import { UserContext } from '../../contexts/UserProvider';
 import { APP_MODE, isProd } from '../../configs/environment';
+import MOBILE_MAX_SIZE from '../../constants/screenSize';
 
 const navigationConfig = [
   {
@@ -41,8 +42,6 @@ const navigationConfig = [
   },
 ];
 
-const MOBILE_SCREEN_SIZE = "420px";
-
 const NavBar = () => {
   const history = useHistory();
   const logoTag = isProd ? 'BETA' : APP_MODE;
@@ -55,7 +54,7 @@ const NavBar = () => {
   const [isWritingDropdownToggled, setWritingDropdownToggled] = useState(false);
   const [isMobile, setIsMobile] = useState(false);
 
-  const mobileScreen = window.matchMedia(`(max-width: ${MOBILE_SCREEN_SIZE})`);
+  const mobileScreen = window.matchMedia(`(max-width: ${MOBILE_MAX_SIZE})`);
 
   const goMain = () => {
     history.push(PATH.ROOT);

--- a/frontend/src/components/NavBar/NavBar.js
+++ b/frontend/src/components/NavBar/NavBar.js
@@ -41,6 +41,8 @@ const navigationConfig = [
   },
 ];
 
+const MOBILE_SCREEN_SIZE = "420px";
+
 const NavBar = () => {
   const history = useHistory();
   const logoTag = isProd ? 'BETA' : APP_MODE;
@@ -52,7 +54,7 @@ const NavBar = () => {
   const [isDropdownToggled, setDropdownToggled] = useState(false);
   const [isWritingDropdownToggled, setWritingDropdownToggled] = useState(false);
 
-  const mobile = window.matchMedia('(max-width: 420px)');
+  const mobileScreen = window.matchMedia(`(max-width: ${MOBILE_SCREEN_SIZE})`);
   const [isMobile, setIsMobile] = useState(false);
 
   const goMain = () => {
@@ -83,13 +85,13 @@ const NavBar = () => {
 
   useEffect(() => {
     const handleResize = () => {
-      setIsMobile(mobile.matches);
+      setIsMobile(mobileScreen.matches);
     };
-    mobile.addEventListener('change', handleResize);
+    mobileScreen.addEventListener('change', handleResize);
     return () => {
-      mobile.removeEventListener('change', handleResize);
+      mobileScreen.removeEventListener('change', handleResize);
     };
-  }, [mobile]);
+  }, [mobileScreen]);
 
   return (
     <Container

--- a/frontend/src/components/NavBar/NavBar.js
+++ b/frontend/src/components/NavBar/NavBar.js
@@ -101,7 +101,7 @@ const NavBar = () => {
     >
       <Wrapper>
         <Logo onClick={goMain} role="link" aria-label="프롤로그 홈으로 이동하기">
-          {isMobile ? <img src={MobileLogo} alt="" /> : <img src={LogoImage} alt="" />}
+          <img src={isMobile ? MobileLogo : LogoImage} alt="" />
           {!isProd && <span>{logoTag}</span>}
         </Logo>
         <Menu role="menu">

--- a/frontend/src/constants/screenSize.js
+++ b/frontend/src/constants/screenSize.js
@@ -1,0 +1,3 @@
+const MOBILE_MAX_SIZE = '420px';
+
+export default MOBILE_MAX_SIZE;


### PR DESCRIPTION
## #️⃣연관된 이슈

> 연관된 이슈 번호를 모두 작성해주세요
>#1270
> ex) #이슈번호, #이슈번호

## 📝작업 내용

> 화면의 사이즈를 줄였을 때, 헤더의 버튼 텍스트가 여러줄로 보이는 현상을 수정
![스크린샷 2023-05-10 오후 4 20 14](https://github.com/woowacourse/prolog/assets/72205402/808702ef-48a8-40e4-86b1-181372d81bb8)

> 모바일 버전일 경우 아이콘 로고로 변경
> <img width="500" alt="스크린샷 2023-05-12 오후 4 32 34" src="https://github.com/woowacourse/prolog/assets/72205402/8cd8db6a-6097-4c34-98a5-5147e75522f5">


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
> text 깨짐 현상이 dev 서버에서는 안 보였습니다. 그래서 첫번째 작업 내용은 prolog 홈페이지에서 개발자 도구에서 변경 후 스크린샷을 찍어서 올립니당.
