### PR TITLE
Fix/#1358 인수테스트(큐컴버)와 통합테스트 독립

### DIFF
--- a/backend/src/acceptanceTest/java/wooteco/prolog/AcceptanceHooks.java
+++ b/backend/src/acceptanceTest/java/wooteco/prolog/AcceptanceHooks.java
@@ -1,5 +1,6 @@
 package wooteco.prolog;
 
+import io.cucumber.java.After;
 import io.cucumber.java.Before;
 import io.cucumber.spring.CucumberContextConfiguration;
 import io.restassured.RestAssured;
@@ -21,6 +22,12 @@ public class AcceptanceHooks {
 
     @Before("@api")
     public void setupForApi() {
+        RestAssured.port = port;
+        dataInitializer.execute();
+    }
+
+    @After("@api")
+    public void deleteForApi() {
         RestAssured.port = port;
         dataInitializer.execute();
     }


### PR DESCRIPTION
## #️⃣연관된 이슈

- #1358 

## 📝작업 내용

- 인수 테스트 이후 @After 어노테이션으로 데이터 초기화


