### PR TITLE
Feature/#1356 로드맵 답변 수정 기능

### DIFF
--- a/frontend/src/apis/essayanswers.ts
+++ b/frontend/src/apis/essayanswers.ts
@@ -1,5 +1,5 @@
 import {client} from '.';
-import {EssayAnswerRequest} from "../models/EssayAnswers";
+import {EssayAnswerRequest, EssayEditRequest} from "../models/EssayAnswers";
 import {AxiosPromise, AxiosResponse} from "axios";
 import {httpRequester} from "./studylogs";
 import {Quiz} from "../models/Keywords";
@@ -11,6 +11,10 @@ export const requestGetEssayAnswer = async (essayAnswerId) => {
 
   return data;
 };
+
+export const requestEditEssayAnswer = async (essayAnswerId: number, body: EssayEditRequest) => {
+  await client.patch(`/essay-answers/${essayAnswerId}`, body);
+}
 
 export const requestDeleteEssayAnswer = async (essayAnswerId) => {
   await client.delete(`/essay-answers/${essayAnswerId}`);

--- a/frontend/src/hooks/EssayAnswer/useEssayAnswer.ts
+++ b/frontend/src/hooks/EssayAnswer/useEssayAnswer.ts
@@ -12,8 +12,7 @@ import useSnackBar from "../useSnackBar";
 
 const useEssayAnswer = () => {
   const { essayAnswerId } = useParams<{ essayAnswerId: string }>();
-  const { user } = useContext(UserContext);
-  const { username, userId } = user;
+  const { user: { username, userId } } = useContext(UserContext);
   const history = useHistory();
   const { openSnackBar } = useSnackBar();
 
@@ -54,6 +53,7 @@ const useEssayAnswer = () => {
 
   return {
     essayAnswer,
+    essayAnswerId,
     deleteEssayAnswer,
     isCurrentUserAuthor,
     isLoading,

--- a/frontend/src/hooks/queries/essayanswer.ts
+++ b/frontend/src/hooks/queries/essayanswer.ts
@@ -2,6 +2,7 @@ import {useMutation, useQuery} from "react-query";
 import {
   createNewEssayAnswerRequest,
   requestDeleteEssayAnswer,
+  requestEditEssayAnswer,
   requestGetEssayAnswer,
   requestGetEssayAnswerList,
   requestGetQuizAsync
@@ -15,6 +16,8 @@ import ERROR_CODE from '../../constants/errorCode';
 import useSnackBar from '../useSnackBar';
 import REACT_QUERY_KEY from "../../constants/reactQueryKey";
 import {Quiz} from "../../models/Keywords";
+import { ERROR_MESSAGE, SUCCESS_MESSAGE } from "../../constants/message";
+import { ResponseError } from "../../apis/studylogs";
 
 export const useCreateNewEssayAnswerMutation = ({
   onSuccess = () => {},
@@ -28,6 +31,27 @@ export const useCreateNewEssayAnswerMutation = ({
       onError?.(error);
     },
   });
+
+export const useEditEssayAnswer = (
+  { essayAnswerId }: { essayAnswerId: number },
+) => {
+  const history = useHistory();
+
+  return useMutation(
+    (data: { answer: string }) =>
+      requestEditEssayAnswer(essayAnswerId, data),
+    {
+      onSuccess: async () => {
+        alert(SUCCESS_MESSAGE.EDIT_POST);
+        history.push(`${PATH.STUDYLOG}/${essayAnswerId}`);
+      },
+
+      onError: (error: ResponseError) => {
+        alert(ERROR_MESSAGE[error.code] ?? ERROR_MESSAGE.FAIL_TO_EDIT_STUDYLOG);
+      },
+    }
+  );
+}
 
 export const useGetEssayAnswer = (
   { essayAnswerId },

--- a/frontend/src/models/EssayAnswers.ts
+++ b/frontend/src/models/EssayAnswers.ts
@@ -6,6 +6,10 @@ export interface EssayAnswerRequest {
   answer: string;
 }
 
+export interface EssayEditRequest {
+  answer: string;
+}
+
 export interface EssayAnswerResponse {
   id: number;
   quiz: Quiz;

--- a/frontend/src/pages/EditEssayAnswerPage/index.tsx
+++ b/frontend/src/pages/EditEssayAnswerPage/index.tsx
@@ -1,0 +1,100 @@
+/** @jsxImportSource @emotion/react */
+
+import {css} from '@emotion/react';
+
+import {MainContentStyle} from '../../PageRouter';
+
+import Editor from '../../components/Editor/Editor';
+import {FlexColumnStyle, FlexStyle} from '../../styles/flex.styles';
+import styled from '@emotion/styled';
+import {ALERT_MESSAGE, COLOR} from '../../constants';
+import {useContext, useEffect, useRef, useState} from "react";
+import { UserContext } from '../../contexts/UserProvider';
+import { useHistory, useParams } from 'react-router';
+import { useEditEssayAnswer, useGetEssayAnswer } from '../../hooks/queries/essayanswer';
+import { EssayAnswerResponse } from '../../models/EssayAnswers';
+
+const EditEssayAnswerPage = () => {
+  const history = useHistory();
+  const { id } = useParams<{ id: string }>();
+
+  const { user: { username } } = useContext(UserContext);
+
+  const [quizTitle, setQuizTitle] = useState<string>('');
+  const [answer, setAnswer] = useState<string | null>(null);
+
+  const editorContentRef = useRef<any>(null);
+
+  const previousEssayAnswer = useGetEssayAnswer(
+    { essayAnswerId: id },
+    {
+      onSuccess: ({ quiz: { question }, answer }: EssayAnswerResponse) => {
+        setAnswer(answer);
+        setQuizTitle(question);
+      },
+    },
+  );
+
+  const author = previousEssayAnswer.data?.author;
+
+  const { mutate: editEssayRequest } = useEditEssayAnswer({
+    essayAnswerId: Number(id),
+  });
+
+  const onEditEssayAnswer = () => {
+    const content = editorContentRef.current?.getInstance().getMarkdown() || '';
+
+    if (content.length === 0) {
+      alert(ALERT_MESSAGE.NO_CONTENT);
+      return;
+    }
+
+    editEssayRequest({
+      answer: content,
+    });
+  };
+
+  useEffect(() => {
+    if (author && username !== author.username) {
+      alert(ALERT_MESSAGE.CANNOT_EDIT_OTHERS);
+      history.goBack();
+    }
+  }, [username, author]);
+
+  useEffect(() => {
+    previousEssayAnswer.refetch();
+  }, [id]);
+
+  return (
+    <div
+      css={[
+        MainContentStyle,
+        FlexStyle,
+        FlexColumnStyle,
+        css`
+          gap: 30px;
+        `,
+      ]}
+    >
+      <Editor
+        title={quizTitle}
+        titleReadOnly={true}
+        height="40vh"
+        content={answer}
+        editorContentRef={editorContentRef}
+      />
+      <SubmitButton type="submit" onClick={onEditEssayAnswer}>
+        제출하기
+      </SubmitButton>
+    </div>
+  );
+};
+
+export default EditEssayAnswerPage;
+
+const SubmitButton = styled.button`
+  background-color: ${COLOR.LIGHT_BLUE_400};
+  width: 100%;
+  border-radius: 4px;
+  padding: 1rem;
+`;

--- a/frontend/src/pages/EssayAnswerPage/index.tsx
+++ b/frontend/src/pages/EssayAnswerPage/index.tsx
@@ -2,26 +2,35 @@
 
 import Content from './Content';
 import {Button, BUTTON_SIZE} from '../../components';
-import {ButtonList} from './styles';
+import {ButtonList, EditButtonStyle} from './styles';
 
 import {MainContentStyle} from '../../PageRouter';
 import useEssayAnswer from "../../hooks/EssayAnswer/useEssayAnswer";
 import {DeleteButtonStyle} from "../LevellogPage/styles";
 import {CONFIRM_MESSAGE} from "../../constants";
+import { useHistory } from 'react-router-dom';
 
 const EssayAnswerPage = () => {
+  const history = useHistory();
+
   const {
     essayAnswer,
+    essayAnswerId,
     deleteEssayAnswer,
     isCurrentUserAuthor,
     isLoading,
   } = useEssayAnswer();
+
+  const goEditTargetPost = () => {
+    history.push(`/essay-answers/${essayAnswerId}/edit`);
+  };
 
   return (
     <div css={MainContentStyle}>
       {isCurrentUserAuthor && (
         <ButtonList>
           {[
+            { title: '수정', cssProps: EditButtonStyle, onClick: goEditTargetPost },
             {
               title: '삭제',
               cssProps: DeleteButtonStyle,

--- a/frontend/src/pages/index.js
+++ b/frontend/src/pages/index.js
@@ -12,3 +12,4 @@ export { default as RoadmapPage } from './RoadmapPage';
 export { default as NewEssayAnswerPage } from './NewEssayAnswerPage';
 export { default as EssayAnswerPage } from './EssayAnswerPage';
 export { default as EssayAnswerListPage } from './EssayAnswerListPage';
+export { default as EditEssayAnswerPage } from './EditEssayAnswerPage';

--- a/frontend/src/routes.js
+++ b/frontend/src/routes.js
@@ -13,6 +13,7 @@ import {
   NewEssayAnswerPage,
   EssayAnswerPage,
   EssayAnswerListPage,
+  EditEssayAnswerPage
 } from './pages';
 
 const pageRoutes = [
@@ -71,6 +72,10 @@ const pageRoutes = [
     path: [PATH.ESSAY_ANSWER_LIST],
     render: () => <EssayAnswerListPage />,
   },
+  {
+    path: '/essay-answers/:id/edit',
+    render: () => <EditEssayAnswerPage />,
+  }
 ];
 
 export default pageRoutes;


### PR DESCRIPTION
## #️⃣연관된 이슈

close #1356

## 📝작업 내용

![image](https://github.com/woowacourse/prolog/assets/77872742/f90b61fc-9df4-47d1-b3da-a7d0c04e5610)

로드맵에서 내가 작성한 글의 경우 `수정` 버튼이 나오도록 추가했어요.

![image](https://github.com/woowacourse/prolog/assets/77872742/1e9939d3-39fd-4049-b8dd-0a7cbeea25f8)

수정 버튼을 눌렀을 때 로드맵 글 수정 페이지로 이동하는 기능을 추가했어요.
페이지 로딩 후 서버와 통신해서 글의 기존 내용을 가져와요!

## 💬리뷰 요구사항(선택)



