### PR TITLE
Fix/#1376 로드맵 답변 수정 후 페이지 이동 문제 해결

### DIFF
--- a/frontend/src/hooks/queries/essayanswer.ts
+++ b/frontend/src/hooks/queries/essayanswer.ts
@@ -41,9 +41,9 @@ export const useEditEssayAnswer = (
     (data: { answer: string }) =>
       requestEditEssayAnswer(essayAnswerId, data),
     {
-      onSuccess: async () => {
+      onSuccess: () => {
         alert(SUCCESS_MESSAGE.EDIT_POST);
-        history.push(`${PATH.STUDYLOG}/${essayAnswerId}`);
+        history.push(`/essay-answers/${essayAnswerId}`);
       },
 
       onError: (error: ResponseError) => {

--- a/frontend/src/hooks/queries/essayanswer.ts
+++ b/frontend/src/hooks/queries/essayanswer.ts
@@ -1,4 +1,4 @@
-import {useMutation, useQuery} from "react-query";
+import { useMutation, useQuery } from 'react-query';
 import {
   createNewEssayAnswerRequest,
   requestDeleteEssayAnswer,
@@ -6,18 +6,18 @@ import {
   requestGetEssayAnswer,
   requestGetEssayAnswerList,
   requestGetQuizAsync
-} from "../../apis/essayanswers";
-import {EssayAnswerRequest, EssayAnswerResponse} from "../../models/EssayAnswers";
+} from '../../apis/essayanswers';
+import { EssayAnswerRequest, EssayAnswerResponse } from '../../models/EssayAnswers';
 
-import {AxiosError} from 'axios';
-import {useHistory} from 'react-router-dom';
-import {ALERT_MESSAGE, PATH} from '../../constants';
+import { AxiosError } from 'axios';
+import { useHistory } from 'react-router-dom';
+import { ALERT_MESSAGE, PATH } from '../../constants';
 import ERROR_CODE from '../../constants/errorCode';
 import useSnackBar from '../useSnackBar';
-import REACT_QUERY_KEY from "../../constants/reactQueryKey";
-import {Quiz} from "../../models/Keywords";
-import { ERROR_MESSAGE, SUCCESS_MESSAGE } from "../../constants/message";
-import { ResponseError } from "../../apis/studylogs";
+import REACT_QUERY_KEY from '../../constants/reactQueryKey';
+import { Quiz } from '../../models/Keywords';
+import { ERROR_MESSAGE, SUCCESS_MESSAGE } from '../../constants/message';
+import { ResponseError } from '../../apis/studylogs';
 
 export const useCreateNewEssayAnswerMutation = ({
   onSuccess = () => {},


### PR DESCRIPTION
## #️⃣연관된 이슈

close #1376

## 📝작업 내용

기존: 로드맵 퀴즈에 등록한 답변을 수정 시 같은 답변 id를 가진 학습로그 글로 이동하는 버그
수정: 수정한 답변 글 상세보기로 이동

