### PR TITLE
fix: 프로덕션 배포 yml의 타입채킹 무시 옵션 임시 활성화

### DIFF
--- a/.github/workflows/front-prod.yml
+++ b/.github/workflows/front-prod.yml
@@ -36,6 +36,7 @@ jobs:
           cd frontend
           yarn build:prd
         env:
+          TSC_COMPILE_ON_ERROR: true # fixme: 타입 검사를 건너뛰고 빌드를 우선 통과시킵니다. 반드시 지워주세요.
           CI: false
 
       - name: Deploy to S3


### PR DESCRIPTION
## 📝작업 내용

fix: 프로덕션 배포 yml의 타입채킹 무시 옵션 임시 활성화

