### PR TITLE
Hotfix: og 태그가 없는 경우 null 을 반환하여 생기는 NPE 해결을 위해 빈문자열 반환

### DIFF
--- a/backend/src/main/java/wooteco/prolog/article/application/OgTagParser.java
+++ b/backend/src/main/java/wooteco/prolog/article/application/OgTagParser.java
@@ -39,7 +39,7 @@ public class OgTagParser {
             final Element element = document.selectFirst(String.format(FORMAT, type.metaTag));
             return Optional.ofNullable(element)
                 .map(it -> it.attr("content"))
-                .orElse(null);
+                .orElse("");
         }
     }
 


### PR DESCRIPTION
## 📝작업 내용

Hotfix: og 태그가 없는 경우 null 을 반환하여 생기는 NPE 해결을 위해 빈문자열 반환

