### PR TITLE
전체 키워드 조회 시 학습 진도를 포함한다

### DIFF
--- a/backend/src/documentation/java/wooteco/prolog/docu/KeywordDocumentation.java
+++ b/backend/src/documentation/java/wooteco/prolog/docu/KeywordDocumentation.java
@@ -108,6 +108,8 @@ public class KeywordDocumentation extends NewDocumentation {
         "자바에 대한 설명을 작성했습니다.",
         1,
         1,
+        0,
+        0,
         null,
         null,
         null
@@ -134,6 +136,8 @@ public class KeywordDocumentation extends NewDocumentation {
         "자바에 대한 설명을 작성했습니다.",
         1,
         1,
+        0,
+        0,
         null,
         null,
         new HashSet<>(
@@ -145,7 +149,6 @@ public class KeywordDocumentation extends NewDocumentation {
                     1,
                     1,
                     1L,
-                    null,
                     null
                 ),
                 new KeywordResponse(
@@ -155,7 +158,6 @@ public class KeywordDocumentation extends NewDocumentation {
                     2,
                     1,
                     1L,
-                    null,
                     null
                 ))
         )

--- a/backend/src/main/java/wooteco/prolog/roadmap/application/RoadMapService.java
+++ b/backend/src/main/java/wooteco/prolog/roadmap/application/RoadMapService.java
@@ -6,6 +6,7 @@ import org.springframework.transaction.annotation.Transactional;
 import wooteco.prolog.common.exception.BadRequestException;
 import wooteco.prolog.roadmap.application.dto.KeywordResponse;
 import wooteco.prolog.roadmap.application.dto.KeywordsResponse;
+import wooteco.prolog.roadmap.application.dto.RecommendedPostResponse;
 import wooteco.prolog.roadmap.domain.Curriculum;
 import wooteco.prolog.roadmap.domain.EssayAnswer;
 import wooteco.prolog.roadmap.domain.Keyword;
@@ -20,8 +21,10 @@ import wooteco.prolog.session.domain.repository.SessionRepository;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 
+import static java.util.stream.Collectors.groupingBy;
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toSet;
 import static wooteco.prolog.common.exception.BadRequestCode.CURRICULUM_NOT_FOUND_EXCEPTION;
 
 @RequiredArgsConstructor
@@ -40,41 +43,49 @@ public class RoadMapService {
         final Curriculum curriculum = curriculumRepository.findById(curriculumId)
             .orElseThrow(() -> new BadRequestException(CURRICULUM_NOT_FOUND_EXCEPTION));
 
+        final List<Keyword> keywordsInCurriculum = getKeywordsInCurriculum(curriculum);
+
+        final Map<Keyword, Set<Quiz>> quizzesInKeywords = quizRepository.findAll().stream()
+            .collect(groupingBy(Quiz::getKeyword, toSet()));
+
+        return createResponsesWithProgress(keywordsInCurriculum, quizzesInKeywords, getDoneQuizzes(memberId));
+    }
+
+    private Set<Quiz> getDoneQuizzes(final Long memberId) {
+        return essayAnswerRepository.findAllByMemberId(memberId).stream()
+            .map(EssayAnswer::getQuiz)
+            .collect(toSet());
+    }
+
+    private List<Keyword> getKeywordsInCurriculum(final Curriculum curriculum) {
         final Set<Long> sessionIds = sessionRepository.findAllByCurriculumId(curriculum.getId())
             .stream()
             .map(Session::getId)
-            .collect(Collectors.toSet());
+            .collect(toSet());
 
-        final List<Keyword> keywords = keywordRepository.findBySessionIdIn(sessionIds);
-
-        final Set<Quiz> doneQuizzes = essayAnswerRepository.findAllByMemberId(memberId).stream()
-            .map(EssayAnswer::getQuiz)
-            .collect(Collectors.toSet());
-
-        final Map<Keyword, Set<Quiz>> quizzesPerKeyword = quizRepository.findAll().stream()
-            .collect(Collectors.groupingBy(Quiz::getKeyword, Collectors.toSet()));
-
-        return createWithProgress(keywords, quizzesPerKeyword, doneQuizzes);
+        return keywordRepository.findBySessionIdIn(sessionIds);
     }
 
-    private KeywordsResponse createWithProgress(final List<Keyword> keywords,
-                                                final Map<Keyword, Set<Quiz>> quizzesPerKeyword,
-                                                final Set<Quiz> doneQuizzes) {
+    private KeywordsResponse createResponsesWithProgress(final List<Keyword> keywords,
+                                                         final Map<Keyword, Set<Quiz>> quizzesPerKeyword,
+                                                         final Set<Quiz> doneQuizzes) {
         final List<KeywordResponse> keywordResponses = keywords.stream()
             .filter(Keyword::isRoot)
-            .map(keyword -> createWithProgress(keyword, quizzesPerKeyword, doneQuizzes))
-            .collect(Collectors.toList());
+            .map(keyword -> createResponseWithProgress(keyword, quizzesPerKeyword, doneQuizzes))
+            .collect(toList());
 
         return new KeywordsResponse(keywordResponses);
     }
 
-    private KeywordResponse createWithProgress(final Keyword keyword,
-                                               final Map<Keyword, Set<Quiz>> quizzesPerKeyword,
-                                               final Set<Quiz> doneQuizzes) {
+    private KeywordResponse createResponseWithProgress(final Keyword keyword,
+                                                       final Map<Keyword, Set<Quiz>> quizzesPerKeyword,
+                                                       final Set<Quiz> doneQuizzes) {
         final int totalQuizCount = quizzesPerKeyword.get(keyword).size();
-        final Set<Quiz> quizzes = quizzesPerKeyword.get(keyword);
-        quizzes.retainAll(doneQuizzes);
-        final int doneQuizCount = quizzes.size();
+        final int doneQuizCount = getDoneQuizCount(quizzesPerKeyword.get(keyword), doneQuizzes);
+
+        final List<RecommendedPostResponse> recommendedPostResponses = keyword.getRecommendedPosts().stream()
+            .map(RecommendedPostResponse::from)
+            .collect(toList());
 
         return new KeywordResponse(
             keyword.getId(),
@@ -85,15 +96,21 @@ public class RoadMapService {
             totalQuizCount,
             doneQuizCount,
             keyword.getParentIdOrNull(),
+            recommendedPostResponses,
             createChildrenWithProgress(keyword.getChildren(), quizzesPerKeyword, doneQuizzes)
         );
+    }
+
+    private int getDoneQuizCount(final Set<Quiz> quizzes, final Set<Quiz> doneQuizzes) {
+        quizzes.retainAll(doneQuizzes);
+        return quizzes.size();
     }
 
     private Set<KeywordResponse> createChildrenWithProgress(final Set<Keyword> children,
                                                             final Map<Keyword, Set<Quiz>> quizzesPerKeyword,
                                                             final Set<Quiz> userAnswers) {
         return children.stream()
-            .map(child -> createWithProgress(child, quizzesPerKeyword, userAnswers))
-            .collect(Collectors.toSet());
+            .map(child -> createResponseWithProgress(child, quizzesPerKeyword, userAnswers))
+            .collect(toSet());
     }
 }

--- a/backend/src/main/java/wooteco/prolog/roadmap/application/RoadMapService.java
+++ b/backend/src/main/java/wooteco/prolog/roadmap/application/RoadMapService.java
@@ -36,21 +36,6 @@ public class RoadMapService {
     private final EssayAnswerRepository essayAnswerRepository;
 
     @Transactional(readOnly = true)
-    public KeywordsResponse findAllKeywords(final Long curriculumId) {
-        final Curriculum curriculum = curriculumRepository.findById(curriculumId)
-            .orElseThrow(() -> new BadRequestException(CURRICULUM_NOT_FOUND_EXCEPTION));
-
-        final Set<Long> sessionIds = sessionRepository.findAllByCurriculumId(curriculum.getId())
-            .stream()
-            .map(Session::getId)
-            .collect(Collectors.toSet());
-
-        final List<Keyword> keywords = keywordRepository.findBySessionIdIn(sessionIds);
-
-        return KeywordsResponse.createResponseWithChildren(keywords);
-    }
-
-    @Transactional(readOnly = true)
     public KeywordsResponse findAllKeywordsWithProgress(final Long curriculumId, final Long memberId) {
         final Curriculum curriculum = curriculumRepository.findById(curriculumId)
             .orElseThrow(() -> new BadRequestException(CURRICULUM_NOT_FOUND_EXCEPTION));
@@ -73,8 +58,8 @@ public class RoadMapService {
     }
 
     private KeywordsResponse createWithProgress(final List<Keyword> keywords,
-                                               final Map<Keyword, Set<Quiz>> quizzesPerKeyword,
-                                               final Set<Quiz> doneQuizzes) {
+                                                final Map<Keyword, Set<Quiz>> quizzesPerKeyword,
+                                                final Set<Quiz> doneQuizzes) {
         final List<KeywordResponse> keywordResponses = keywords.stream()
             .filter(Keyword::isRoot)
             .map(keyword -> createWithProgress(keyword, quizzesPerKeyword, doneQuizzes))

--- a/backend/src/main/java/wooteco/prolog/roadmap/application/RoadMapService.java
+++ b/backend/src/main/java/wooteco/prolog/roadmap/application/RoadMapService.java
@@ -1,21 +1,28 @@
 package wooteco.prolog.roadmap.application;
 
-import static wooteco.prolog.common.exception.BadRequestCode.CURRICULUM_NOT_FOUND_EXCEPTION;
-
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import wooteco.prolog.common.exception.BadRequestException;
+import wooteco.prolog.roadmap.application.dto.KeywordResponse;
 import wooteco.prolog.roadmap.application.dto.KeywordsResponse;
 import wooteco.prolog.roadmap.domain.Curriculum;
+import wooteco.prolog.roadmap.domain.EssayAnswer;
 import wooteco.prolog.roadmap.domain.Keyword;
+import wooteco.prolog.roadmap.domain.Quiz;
 import wooteco.prolog.roadmap.domain.repository.CurriculumRepository;
+import wooteco.prolog.roadmap.domain.repository.EssayAnswerRepository;
 import wooteco.prolog.roadmap.domain.repository.KeywordRepository;
+import wooteco.prolog.roadmap.domain.repository.QuizRepository;
 import wooteco.prolog.session.domain.Session;
 import wooteco.prolog.session.domain.repository.SessionRepository;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static wooteco.prolog.common.exception.BadRequestCode.CURRICULUM_NOT_FOUND_EXCEPTION;
 
 @RequiredArgsConstructor
 @Transactional
@@ -25,6 +32,8 @@ public class RoadMapService {
     private final CurriculumRepository curriculumRepository;
     private final SessionRepository sessionRepository;
     private final KeywordRepository keywordRepository;
+    private final QuizRepository quizRepository;
+    private final EssayAnswerRepository essayAnswerRepository;
 
     @Transactional(readOnly = true)
     public KeywordsResponse findAllKeywords(final Long curriculumId) {
@@ -39,5 +48,67 @@ public class RoadMapService {
         final List<Keyword> keywords = keywordRepository.findBySessionIdIn(sessionIds);
 
         return KeywordsResponse.createResponseWithChildren(keywords);
+    }
+
+    @Transactional(readOnly = true)
+    public KeywordsResponse findAllKeywordsWithProgress(final Long curriculumId, final Long memberId) {
+        final Curriculum curriculum = curriculumRepository.findById(curriculumId)
+            .orElseThrow(() -> new BadRequestException(CURRICULUM_NOT_FOUND_EXCEPTION));
+
+        final Set<Long> sessionIds = sessionRepository.findAllByCurriculumId(curriculum.getId())
+            .stream()
+            .map(Session::getId)
+            .collect(Collectors.toSet());
+
+        final List<Keyword> keywords = keywordRepository.findBySessionIdIn(sessionIds);
+
+        final Set<Quiz> doneQuizzes = essayAnswerRepository.findAllByMemberId(memberId).stream()
+            .map(EssayAnswer::getQuiz)
+            .collect(Collectors.toSet());
+
+        final Map<Keyword, Set<Quiz>> quizzesPerKeyword = quizRepository.findAll().stream()
+            .collect(Collectors.groupingBy(Quiz::getKeyword, Collectors.toSet()));
+
+        return createWithProgress(keywords, quizzesPerKeyword, doneQuizzes);
+    }
+
+    private KeywordsResponse createWithProgress(final List<Keyword> keywords,
+                                               final Map<Keyword, Set<Quiz>> quizzesPerKeyword,
+                                               final Set<Quiz> doneQuizzes) {
+        final List<KeywordResponse> keywordResponses = keywords.stream()
+            .filter(Keyword::isRoot)
+            .map(keyword -> createWithProgress(keyword, quizzesPerKeyword, doneQuizzes))
+            .collect(Collectors.toList());
+
+        return new KeywordsResponse(keywordResponses);
+    }
+
+    private KeywordResponse createWithProgress(final Keyword keyword,
+                                               final Map<Keyword, Set<Quiz>> quizzesPerKeyword,
+                                               final Set<Quiz> doneQuizzes) {
+        final int totalQuizCount = quizzesPerKeyword.get(keyword).size();
+        final Set<Quiz> quizzes = quizzesPerKeyword.get(keyword);
+        quizzes.retainAll(doneQuizzes);
+        final int doneQuizCount = quizzes.size();
+
+        return new KeywordResponse(
+            keyword.getId(),
+            keyword.getName(),
+            keyword.getDescription(),
+            keyword.getSeq(),
+            keyword.getImportance(),
+            totalQuizCount,
+            doneQuizCount,
+            keyword.getParentIdOrNull(),
+            createChildrenWithProgress(keyword.getChildren(), quizzesPerKeyword, doneQuizzes)
+        );
+    }
+
+    private Set<KeywordResponse> createChildrenWithProgress(final Set<Keyword> children,
+                                                            final Map<Keyword, Set<Quiz>> quizzesPerKeyword,
+                                                            final Set<Quiz> userAnswers) {
+        return children.stream()
+            .map(child -> createWithProgress(child, quizzesPerKeyword, userAnswers))
+            .collect(Collectors.toSet());
     }
 }

--- a/backend/src/main/java/wooteco/prolog/roadmap/application/dto/KeywordResponse.java
+++ b/backend/src/main/java/wooteco/prolog/roadmap/application/dto/KeywordResponse.java
@@ -5,10 +5,16 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import wooteco.prolog.roadmap.domain.Keyword;
 
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
+
+import static java.util.Collections.*;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
@@ -19,13 +25,15 @@ public class KeywordResponse {
     private String description;
     private int order;
     private int importance;
+    private int totalQuizCount;
+    private int doneQuizCount;
     private Long parentKeywordId;
     private List<RecommendedPostResponse> recommendedPosts;
     private Set<KeywordResponse> childrenKeywords;
 
     public KeywordResponse(final Long keywordId, final String name, final String description,
-                           final int order,
-                           final int importance, final Long parentKeywordId,
+                           final int order, final int importance, final int totalQuizCount,
+                           final int doneQuizCount, final Long parentKeywordId,
                            final List<RecommendedPostResponse> recommendedPosts,
                            final Set<KeywordResponse> childrenKeywords) {
         this.keywordId = keywordId;
@@ -33,9 +41,18 @@ public class KeywordResponse {
         this.description = description;
         this.order = order;
         this.importance = importance;
+        this.totalQuizCount = totalQuizCount;
+        this.doneQuizCount = doneQuizCount;
         this.parentKeywordId = parentKeywordId;
         this.recommendedPosts = recommendedPosts;
         this.childrenKeywords = childrenKeywords;
+    }
+
+    public KeywordResponse(final Long keywordId, final String name, final String description,
+                           final int order,
+                           final int importance, final Long parentKeywordId,
+                           final Set<KeywordResponse> childrenKeywords) {
+        this(keywordId, name, description, order, importance, 0, 0, parentKeywordId, emptyList(), childrenKeywords);
     }
 
     public static KeywordResponse createResponse(final Keyword keyword) {
@@ -45,6 +62,7 @@ public class KeywordResponse {
             keyword.getDescription(),
             keyword.getSeq(),
             keyword.getImportance(),
+            0, 0,
             keyword.getParentIdOrNull(),
             createRecommendedPostResponses(keyword),
             null);
@@ -64,11 +82,10 @@ public class KeywordResponse {
             keyword.getSeq(),
             keyword.getImportance(),
             keyword.getParentIdOrNull(),
-            createRecommendedPostResponses(keyword),
-            createKeywordChild(keyword.getChildren()));
+            createChildren(keyword.getChildren()));
     }
 
-    private static Set<KeywordResponse> createKeywordChild(final Set<Keyword> children) {
+    private static Set<KeywordResponse> createChildren(final Set<Keyword> children) {
         Set<KeywordResponse> keywords = new HashSet<>();
         for (Keyword keyword : children) {
             keywords.add(createWithAllChildResponse(keyword));

--- a/backend/src/main/java/wooteco/prolog/roadmap/domain/repository/EssayAnswerRepository.java
+++ b/backend/src/main/java/wooteco/prolog/roadmap/domain/repository/EssayAnswerRepository.java
@@ -1,11 +1,13 @@
 package wooteco.prolog.roadmap.domain.repository;
 
-import java.util.List;
-import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.repository.query.Param;
 import wooteco.prolog.roadmap.domain.EssayAnswer;
+
+import java.util.List;
+import java.util.Optional;
 
 public interface EssayAnswerRepository extends JpaRepository<EssayAnswer, Long>,
     JpaSpecificationExecutor<EssayAnswer> {
@@ -16,4 +18,9 @@ public interface EssayAnswerRepository extends JpaRepository<EssayAnswer, Long>,
     Optional<EssayAnswer> findByIdAndMemberId(Long id, Long memberId);
 
     List<EssayAnswer> findByQuizIdOrderByIdDesc(Long quizId);
+
+    @Query("SELECT e FROM EssayAnswer e " +
+        "LEFT JOIN FETCH e.quiz " +
+        "WHERE e.member.id = :memberId")
+    List<EssayAnswer> findAllByMemberId(@Param("memberId") Long memberId);
 }

--- a/backend/src/main/java/wooteco/prolog/roadmap/domain/repository/EssayAnswerRepository.java
+++ b/backend/src/main/java/wooteco/prolog/roadmap/domain/repository/EssayAnswerRepository.java
@@ -8,6 +8,7 @@ import wooteco.prolog.roadmap.domain.EssayAnswer;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 public interface EssayAnswerRepository extends JpaRepository<EssayAnswer, Long>,
     JpaSpecificationExecutor<EssayAnswer> {
@@ -20,7 +21,8 @@ public interface EssayAnswerRepository extends JpaRepository<EssayAnswer, Long>,
     List<EssayAnswer> findByQuizIdOrderByIdDesc(Long quizId);
 
     @Query("SELECT e FROM EssayAnswer e " +
-        "LEFT JOIN FETCH e.quiz " +
+        "LEFT JOIN FETCH e.quiz q " +
+        "LEFT JOIN FETCH q.keyword " +
         "WHERE e.member.id = :memberId")
-    List<EssayAnswer> findAllByMemberId(@Param("memberId") Long memberId);
+    Set<EssayAnswer> findAllByMemberId(@Param("memberId") Long memberId);
 }

--- a/backend/src/main/java/wooteco/prolog/roadmap/domain/repository/EssayAnswerRepository.java
+++ b/backend/src/main/java/wooteco/prolog/roadmap/domain/repository/EssayAnswerRepository.java
@@ -22,7 +22,6 @@ public interface EssayAnswerRepository extends JpaRepository<EssayAnswer, Long>,
 
     @Query("SELECT e FROM EssayAnswer e " +
         "LEFT JOIN FETCH e.quiz q " +
-        "LEFT JOIN FETCH q.keyword " +
         "WHERE e.member.id = :memberId")
     Set<EssayAnswer> findAllByMemberId(@Param("memberId") Long memberId);
 }

--- a/backend/src/main/java/wooteco/prolog/roadmap/ui/RoadmapController.java
+++ b/backend/src/main/java/wooteco/prolog/roadmap/ui/RoadmapController.java
@@ -4,6 +4,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import wooteco.prolog.login.domain.AuthMemberPrincipal;
+import wooteco.prolog.login.ui.LoginMember;
 import wooteco.prolog.roadmap.application.RoadMapService;
 import wooteco.prolog.roadmap.application.dto.KeywordsResponse;
 
@@ -14,7 +16,8 @@ public class RoadmapController {
     private final RoadMapService roadMapService;
 
     @GetMapping("/roadmaps")
-    public KeywordsResponse findRoadMapKeyword(@RequestParam final Long curriculumId) {
-        return roadMapService.findAllKeywords(curriculumId);
+    public KeywordsResponse findRoadMapKeyword(@AuthMemberPrincipal final LoginMember member,
+                                               @RequestParam final Long curriculumId) {
+        return roadMapService.findAllKeywordsWithProgress(curriculumId, member.getId());
     }
 }

--- a/backend/src/test/java/wooteco/prolog/roadmap/application/RoadMapServiceTest.java
+++ b/backend/src/test/java/wooteco/prolog/roadmap/application/RoadMapServiceTest.java
@@ -1,27 +1,37 @@
 package wooteco.prolog.roadmap.application;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.Mockito.when;
-
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import wooteco.prolog.member.domain.Member;
+import wooteco.prolog.member.domain.Role;
+import wooteco.prolog.roadmap.application.dto.KeywordResponse;
 import wooteco.prolog.roadmap.application.dto.KeywordsResponse;
 import wooteco.prolog.roadmap.domain.Curriculum;
+import wooteco.prolog.roadmap.domain.EssayAnswer;
 import wooteco.prolog.roadmap.domain.Keyword;
+import wooteco.prolog.roadmap.domain.Quiz;
 import wooteco.prolog.roadmap.domain.repository.CurriculumRepository;
+import wooteco.prolog.roadmap.domain.repository.EssayAnswerRepository;
 import wooteco.prolog.roadmap.domain.repository.KeywordRepository;
+import wooteco.prolog.roadmap.domain.repository.QuizRepository;
 import wooteco.prolog.session.domain.Session;
 import wooteco.prolog.session.domain.repository.SessionRepository;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class RoadMapServiceTest {
@@ -32,6 +42,10 @@ class RoadMapServiceTest {
     private SessionRepository sessionRepository;
     @Mock
     private KeywordRepository keywordRepository;
+    @Mock
+    private QuizRepository quizRepository;
+    @Mock
+    private EssayAnswerRepository essayAnswerRepository;
     @InjectMocks
     private RoadMapService roadMapService;
 
@@ -64,5 +78,46 @@ class RoadMapServiceTest {
         assertThat(actual)
             .usingRecursiveComparison()
             .isEqualTo(expected);
+    }
+
+    @Test
+    @DisplayName("curriculumId가 주어지면 해당 커리큘럼의 키워드들을 학습 진도와 함께 전부 조회할 수 있다.")
+    void findAllKeywordsWithProgress() {
+        //given
+        final Curriculum curriculum = new Curriculum(1L, "커리큘럼1");
+        final Session session = new Session(1L, curriculum.getId(), "세션1");
+        final List<Session> sessions = Arrays.asList(session);
+        final Keyword keyword = new Keyword(1L, "자바1", "자바 설명1", 1, 5, session.getId(),
+            null, Collections.emptySet());
+        final Quiz quiz = new Quiz(1L, keyword, "자바8을 왜 쓰나요?");
+        final Member member = new Member(1L, "연어", "참치", Role.CREW, 1L, "image");
+        final EssayAnswer essayAnswer = new EssayAnswer(quiz, "쓰라고 해서요ㅠㅠ", member);
+
+        when(curriculumRepository.findById(anyLong()))
+            .thenReturn(Optional.of(curriculum));
+
+        when(sessionRepository.findAllByCurriculumId(anyLong()))
+            .thenReturn(sessions);
+
+        when(keywordRepository.findBySessionIdIn(any()))
+            .thenReturn(Arrays.asList(keyword));
+
+        when(essayAnswerRepository.findAllByMemberId(1L))
+            .thenReturn(new HashSet<>(Arrays.asList(essayAnswer)));
+
+        when(quizRepository.findAll())
+            .thenReturn(Arrays.asList(quiz));
+
+        //when
+        final KeywordsResponse actual =
+            roadMapService.findAllKeywordsWithProgress(curriculum.getId(), 1L);
+
+        //then
+        final List<KeywordResponse> responses = actual.getData();
+        assertSoftly(soft -> {
+            assertThat(responses).hasSize(1);
+            assertThat(responses.get(0).getDoneQuizCount()).isOne();
+            assertThat(responses.get(0).getTotalQuizCount()).isOne();
+        });
     }
 }

--- a/backend/src/test/java/wooteco/prolog/roadmap/application/RoadMapServiceTest.java
+++ b/backend/src/test/java/wooteco/prolog/roadmap/application/RoadMapServiceTest.java
@@ -50,37 +50,6 @@ class RoadMapServiceTest {
     private RoadMapService roadMapService;
 
     @Test
-    @DisplayName("curriculumId가 주어지면 해당 커리큘럼의 키워드들을 전부 조회할 수 있다.")
-    void findAllKeywords() {
-        //given
-        final Curriculum curriculum = new Curriculum(1L, "커리큘럼1");
-        final Session session = new Session(1L, curriculum.getId(), "세션1");
-        final List<Session> sessions = Arrays.asList(session);
-        final Keyword keyword = new Keyword(1L, "자바1", "자바 설명1", 1, 5, session.getId(),
-            null, Collections.emptySet());
-
-        when(curriculumRepository.findById(anyLong()))
-            .thenReturn(Optional.of(curriculum));
-
-        when(sessionRepository.findAllByCurriculumId(anyLong()))
-            .thenReturn(sessions);
-
-        when(keywordRepository.findBySessionIdIn(any()))
-            .thenReturn(Arrays.asList(keyword));
-
-        final KeywordsResponse expected = KeywordsResponse.createResponseWithChildren(Arrays.asList(keyword));
-
-        //when
-        final KeywordsResponse actual =
-            roadMapService.findAllKeywords(curriculum.getId());
-
-        //then
-        assertThat(actual)
-            .usingRecursiveComparison()
-            .isEqualTo(expected);
-    }
-
-    @Test
     @DisplayName("curriculumId가 주어지면 해당 커리큘럼의 키워드들을 학습 진도와 함께 전부 조회할 수 있다.")
     void findAllKeywordsWithProgress() {
         //given

--- a/backend/src/test/java/wooteco/prolog/roadmap/repository/EssayAnswerRepositoryTest.java
+++ b/backend/src/test/java/wooteco/prolog/roadmap/repository/EssayAnswerRepositoryTest.java
@@ -1,7 +1,5 @@
 package wooteco.prolog.roadmap.repository;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -13,6 +11,12 @@ import wooteco.prolog.roadmap.domain.Quiz;
 import wooteco.prolog.roadmap.domain.repository.EssayAnswerRepository;
 import wooteco.support.utils.RepositoryTest;
 
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
 @RepositoryTest
 class EssayAnswerRepositoryTest {
 
@@ -22,13 +26,39 @@ class EssayAnswerRepositoryTest {
     @DisplayName("퀴즈에 대한 서술형 답변을 저장한다.")
     @Test
     void save() {
-        Keyword keyword = Keyword.createKeyword("자바", "자바 설명", 1, 5, 1L, null);
-        Quiz quiz = new Quiz(1L, keyword, "자바 언어의 특징은?");
-        Member member = new Member(11L, "username", "nickname", Role.CREW, 101L, "https://");
-        EssayAnswer essayAnswer = new EssayAnswer(quiz, "객체 지향 언어", member);
+        final EssayAnswer essayAnswer = createEssayAnswer(createQuizWithPK(1L));
 
         essayAnswerRepository.save(essayAnswer);
 
         assertThat(essayAnswer.getId()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("멤버가 쓴 전체 답변들을 가져온다.")
+    void findAllByMemberId() {
+        //given
+        final int expectedCount = 10;
+        final List<EssayAnswer> answers = Stream.iterate(0, i -> i + 1)
+            .limit(expectedCount)
+            .map(this::createQuizWithPK)
+            .map(this::createEssayAnswer)
+            .collect(Collectors.toList());
+        essayAnswerRepository.saveAll(answers);
+
+        //when
+        final List<EssayAnswer> essayAnswers = essayAnswerRepository.findAllByMemberId(11L);
+
+        //then
+        assertThat(essayAnswers).hasSize(expectedCount);
+    }
+
+    private EssayAnswer createEssayAnswer(final Quiz quiz) {
+        Member member = new Member(11L, "username", "nickname", Role.CREW, 101L, "https://");
+        return new EssayAnswer(quiz, "객체 지향 언어", member);
+    }
+
+    private Quiz createQuizWithPK(final long id) {
+        Keyword keyword = Keyword.createKeyword("자바", "자바 설명", 1, 5, 1L, null);
+        return new Quiz(id, keyword, "자바 연어의 특징은?");
     }
 }

--- a/backend/src/test/java/wooteco/prolog/roadmap/repository/EssayAnswerRepositoryTest.java
+++ b/backend/src/test/java/wooteco/prolog/roadmap/repository/EssayAnswerRepositoryTest.java
@@ -12,6 +12,7 @@ import wooteco.prolog.roadmap.domain.repository.EssayAnswerRepository;
 import wooteco.support.utils.RepositoryTest;
 
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -46,7 +47,7 @@ class EssayAnswerRepositoryTest {
         essayAnswerRepository.saveAll(answers);
 
         //when
-        final List<EssayAnswer> essayAnswers = essayAnswerRepository.findAllByMemberId(11L);
+        final Set<EssayAnswer> essayAnswers = essayAnswerRepository.findAllByMemberId(11L);
 
         //then
         assertThat(essayAnswers).hasSize(expectedCount);


### PR DESCRIPTION
## #️⃣연관된 이슈
- #1473 

## 📝작업 내용
- RoadmapService의 전체 키워드 조회 시 현재 로그인 유저의 진도율을 표시한다

## 💬리뷰 요구사항(선택)
- 기존의 KeywordController, KeywordService는 어드민에서 쓰는 것 같은데 얘네는 반영하지 않았습니다.
- RoadmapController와 RoadmapService만 진행했습니다.

