### PR TITLE
KeywordResponse에서 추천 포스트 emptyList 반환 로직 제거

### DIFF
--- a/backend/src/documentation/java/wooteco/prolog/docu/KeywordDocumentation.java
+++ b/backend/src/documentation/java/wooteco/prolog/docu/KeywordDocumentation.java
@@ -17,13 +17,14 @@ import wooteco.prolog.roadmap.ui.KeywordController;
 import java.util.Arrays;
 import java.util.HashSet;
 
+import static java.util.Collections.emptyList;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 
 @WebMvcTest(controllers = KeywordController.class)
-public class KeywordDocumentation extends NewDocumentation {
+class KeywordDocumentation extends NewDocumentation {
 
     @MockBean
     private KeywordService keywordService;
@@ -148,7 +149,10 @@ public class KeywordDocumentation extends NewDocumentation {
                     "자바의 자료구조인 List에 대한 설명을 작성했습니다.",
                     1,
                     1,
+                    0,
+                    0,
                     1L,
+                    emptyList(),
                     null
                 ),
                 new KeywordResponse(
@@ -157,7 +161,10 @@ public class KeywordDocumentation extends NewDocumentation {
                     "자바의 자료구조인 Set에 대한 설명을 작성했습니다.",
                     2,
                     1,
+                    0,
+                    0,
                     1L,
+                    emptyList(),
                     null
                 ))
         )

--- a/backend/src/main/java/wooteco/prolog/roadmap/application/dto/KeywordResponse.java
+++ b/backend/src/main/java/wooteco/prolog/roadmap/application/dto/KeywordResponse.java
@@ -5,16 +5,10 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import wooteco.prolog.roadmap.domain.Keyword;
 
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Set;
-
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
-
-import static java.util.Collections.*;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
@@ -48,13 +42,6 @@ public class KeywordResponse {
         this.childrenKeywords = childrenKeywords;
     }
 
-    public KeywordResponse(final Long keywordId, final String name, final String description,
-                           final int order,
-                           final int importance, final Long parentKeywordId,
-                           final Set<KeywordResponse> childrenKeywords) {
-        this(keywordId, name, description, order, importance, 0, 0, parentKeywordId, emptyList(), childrenKeywords);
-    }
-
     public static KeywordResponse createResponse(final Keyword keyword) {
         return new KeywordResponse(
             keyword.getId(),
@@ -81,7 +68,10 @@ public class KeywordResponse {
             keyword.getDescription(),
             keyword.getSeq(),
             keyword.getImportance(),
+            0,
+            0,
             keyword.getParentIdOrNull(),
+            createRecommendedPostResponses(keyword),
             createChildren(keyword.getChildren()));
     }
 


### PR DESCRIPTION
## #️⃣연관된 이슈
- closed #1542

## 📝작업 내용
- 생성자의 오버로딩 버전(문제 원인) 제거


