### PR TITLE
Safari에서 로드맵 퀴즈 progress가 표시되지 않는 오류를 수정

### DIFF
--- a/frontend/src/pages/RoadmapPage/components/Roadmap/SubKeyword.tsx
+++ b/frontend/src/pages/RoadmapPage/components/Roadmap/SubKeyword.tsx
@@ -29,7 +29,7 @@ const SubKeyword = (props: SubKeywordProps) => {
         font-weight: bold;
         cursor: pointer;
         border-radius: 4px;
-        overflow: hidden;
+        overflow: visible;
 
         &:hover {
           background: ${hsl(toAdjustedLightness(toHue(KeywordColors.SUB_KEYWORD, hue), -0.1))};
@@ -48,9 +48,8 @@ const SubKeyword = (props: SubKeywordProps) => {
           display: flex;
           align-items: flex-start;
           justify-content: flex-end;
-          position: absolute;
-          top: -5px;
-          right: -5px;
+          margin-right: -5px;
+          margin-top: -5px;
         `}
       >
         <QuizProgress totalCount={keyword.totalQuizCount} doneCount={keyword.doneQuizCount} />
@@ -64,6 +63,8 @@ const SubKeyword = (props: SubKeywordProps) => {
             : 'transparent'};
           margin-right: auto;
           box-shadow: inset 1px 0 1px 1px rgba(0, 0, 0, 0.05);
+          border-top-left-radius: 4px;
+          border-bottom-left-radius: 4px;
         `}
       />
       <div


### PR DESCRIPTION
## #️⃣연관된 이슈
resolve #1603

## 📝작업 내용
<img width="1047" alt="image" src="https://github.com/woowacourse/prolog/assets/72205402/e30aaf8a-83c0-4210-87af-38b9733ea060">

* Safari에서 로드맵 퀴즈 progress가 표시되지 않는 오류를 수정하였습니다