### PR TITLE
커리큘럼 별 퀴즈 API 생성

### DIFF
--- a/backend/src/documentation/adoc/quiz.adoc
+++ b/backend/src/documentation/adoc/quiz.adoc
@@ -25,11 +25,21 @@ include::{snippets}/quiz/detail/http-response.adoc[]
 
 ==== Request
 
-include::{snippets}/quiz/list/http-request.adoc[]
+include::{snippets}/quiz/list-keyword/http-request.adoc[]
 
 ==== Response
 
-include::{snippets}/quiz/list/http-response.adoc[]
+include::{snippets}/quiz/list-keyword/http-response.adoc[]
+
+=== 커리큘럼별 퀴즈 목록 조회
+
+==== Request
+
+include::{snippets}/quiz/list-curriculum/http-request.adoc[]
+
+==== Response
+
+include::{snippets}/quiz/list-curriculum/http-response.adoc[]
 
 === 퀴즈 삭제
 

--- a/backend/src/documentation/java/wooteco/prolog/docu/QuizDocumentation.java
+++ b/backend/src/documentation/java/wooteco/prolog/docu/QuizDocumentation.java
@@ -2,17 +2,24 @@ package wooteco.prolog.docu;
 
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 
 import java.util.Arrays;
+import java.util.List;
 import org.junit.jupiter.api.Test;
+import org.mockito.BDDMockito;
+import org.mockito.Mockito;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpStatus;
 import wooteco.prolog.NewDocumentation;
 import wooteco.prolog.roadmap.application.QuizService;
+import wooteco.prolog.roadmap.application.dto.CurriculumQuizResponse;
 import wooteco.prolog.roadmap.application.dto.QuizRequest;
 import wooteco.prolog.roadmap.application.dto.QuizResponse;
 import wooteco.prolog.roadmap.application.dto.QuizzesResponse;
@@ -61,8 +68,45 @@ public class QuizDocumentation extends NewDocumentation {
 
         given
             .when().get("/sessions/{sessionId}/keywords/{keywordId}/quizs", 1L, 1L)
-            .then().log().all().apply(document("quiz/list"))
+            .then().log().all().apply(document("quiz/list-keyword"))
             .statusCode(HttpStatus.OK.value());
+    }
+
+    @Test
+    void Curriculum별_Quiz_조회() {
+        given(quizService.findQuizzesByCurriculumId(anyLong()))
+            .willReturn(makeMockResponse());
+
+        given
+            .when().get("/curriculums/{curriculumId}/quizzes", 1L)
+            .then().log().all().apply(document("quiz/list-curriculum"))
+            .statusCode(HttpStatus.OK.value());
+    }
+
+    private List<CurriculumQuizResponse> makeMockResponse() {
+        CurriculumQuizResponse response1 = new CurriculumQuizResponse() {
+            @Override
+            public Long getId() {
+                return 1L;
+            }
+
+            @Override
+            public String getQuestion() {
+                return "question1";
+            }
+        };
+        CurriculumQuizResponse response2 = new CurriculumQuizResponse() {
+            @Override
+            public Long getId() {
+                return 2L;
+            }
+
+            @Override
+            public String getQuestion() {
+                return "question2";
+            }
+        };
+        return Arrays.asList(response1, response2);
     }
 
     @Test

--- a/backend/src/main/java/wooteco/prolog/roadmap/application/QuizService.java
+++ b/backend/src/main/java/wooteco/prolog/roadmap/application/QuizService.java
@@ -11,6 +11,7 @@ import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import wooteco.prolog.common.exception.BadRequestException;
+import wooteco.prolog.roadmap.application.dto.CurriculumQuizResponse;
 import wooteco.prolog.roadmap.application.dto.QuizRequest;
 import wooteco.prolog.roadmap.application.dto.QuizResponse;
 import wooteco.prolog.roadmap.application.dto.QuizzesResponse;
@@ -72,5 +73,9 @@ public class QuizService {
         final Quiz quiz = quizRepository.findById(quizId)
             .orElseThrow(() -> new BadRequestException(ROADMAP_QUIZ_NOT_FOUND_EXCEPTION));
         return QuizResponse.of(quiz, isLearning(memberId, quizId));
+    }
+
+    public List<CurriculumQuizResponse> findQuizzesByCurriculumId(Long curriculumId) {
+        return quizRepository.findQuizzesByCurriculum(curriculumId);
     }
 }

--- a/backend/src/main/java/wooteco/prolog/roadmap/application/dto/CurriculumQuizResponse.java
+++ b/backend/src/main/java/wooteco/prolog/roadmap/application/dto/CurriculumQuizResponse.java
@@ -1,0 +1,8 @@
+package wooteco.prolog.roadmap.application.dto;
+
+public interface CurriculumQuizResponse {
+
+    Long getId();
+
+    String getQuestion();
+}

--- a/backend/src/main/java/wooteco/prolog/roadmap/domain/repository/QuizRepository.java
+++ b/backend/src/main/java/wooteco/prolog/roadmap/domain/repository/QuizRepository.java
@@ -3,6 +3,8 @@ package wooteco.prolog.roadmap.domain.repository;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import wooteco.prolog.roadmap.application.dto.CurriculumQuizResponse;
 import wooteco.prolog.roadmap.domain.Quiz;
 
 public interface QuizRepository extends JpaRepository<Quiz, Long> {
@@ -11,4 +13,12 @@ public interface QuizRepository extends JpaRepository<Quiz, Long> {
         + " JOIN FETCH q.keyword k"
         + " WHERE q.keyword.id = :keywordId")
     List<Quiz> findFetchQuizByKeywordId(Long keywordId);
+
+    @Query(nativeQuery = true,
+        value = "SELECT q.id, q.question " +
+            "FROM curriculum c " +
+                "JOIN session s ON c.id = :curriculumId AND s.curriculum_id = c.id " +
+                "JOIN keyword k ON k.session_id = s.id " +
+                "JOIN quiz q ON q.keyword_id = k.id")
+    List<CurriculumQuizResponse> findQuizzesByCurriculum(@Param("curriculumId") Long curriculumId);
 }

--- a/backend/src/main/java/wooteco/prolog/roadmap/ui/QuizController.java
+++ b/backend/src/main/java/wooteco/prolog/roadmap/ui/QuizController.java
@@ -1,6 +1,7 @@
 package wooteco.prolog.roadmap.ui;
 
 import java.net.URI;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -14,6 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 import wooteco.prolog.login.domain.AuthMemberPrincipal;
 import wooteco.prolog.login.ui.LoginMember;
 import wooteco.prolog.roadmap.application.QuizService;
+import wooteco.prolog.roadmap.application.dto.CurriculumQuizResponse;
 import wooteco.prolog.roadmap.application.dto.QuizRequest;
 import wooteco.prolog.roadmap.application.dto.QuizResponse;
 import wooteco.prolog.roadmap.application.dto.QuizzesResponse;
@@ -62,6 +64,13 @@ public class QuizController {
         @AuthMemberPrincipal LoginMember member
     ) {
         return ResponseEntity.ok(quizService.findQuizzesByKeywordId(keywordId, member.getId()));
+    }
+
+    @GetMapping("/curriculums/{curriculumId}/quizzes")
+    public ResponseEntity<List<CurriculumQuizResponse>> findQuizzesByCurriculum(
+        @PathVariable Long curriculumId
+    ) {
+        return ResponseEntity.ok(quizService.findQuizzesByCurriculumId(curriculumId));
     }
 
     @PutMapping("/sessions/{sessionId}/keywords/{keywordId}/quizs/{quizId}")

--- a/backend/src/test/java/wooteco/prolog/roadmap/repository/QuizRepositoryTest.java
+++ b/backend/src/test/java/wooteco/prolog/roadmap/repository/QuizRepositoryTest.java
@@ -1,5 +1,7 @@
 package wooteco.prolog.roadmap.repository;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.Arrays;
 import java.util.List;
 import org.assertj.core.api.Assertions;
@@ -7,8 +9,11 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import wooteco.prolog.roadmap.application.dto.CurriculumQuizResponse;
+import wooteco.prolog.roadmap.domain.Curriculum;
 import wooteco.prolog.roadmap.domain.Keyword;
 import wooteco.prolog.roadmap.domain.Quiz;
+import wooteco.prolog.roadmap.domain.repository.CurriculumRepository;
 import wooteco.prolog.roadmap.domain.repository.KeywordRepository;
 import wooteco.prolog.roadmap.domain.repository.QuizRepository;
 import wooteco.prolog.session.domain.Session;
@@ -25,7 +30,12 @@ class QuizRepositoryTest {
     private KeywordRepository keywordRepository;
 
     @Autowired
+    private CurriculumRepository curriculumRepository;
+
+    @Autowired
     private SessionRepository sessionRepository;
+
+    private Curriculum 백엔드;
 
     private Session session_백엔드_레벨1;
 
@@ -38,15 +48,15 @@ class QuizRepositoryTest {
 
     @BeforeEach
     void setUp() {
-        session_백엔드_레벨1 = sessionRepository.save(new Session("백엔드Java 레벨1"));
+        백엔드 = curriculumRepository.save(new Curriculum("백엔드"));
+
+        session_백엔드_레벨1 = sessionRepository.save(new Session(백엔드.getId(), "백엔드Java 레벨1"));
 
         자바 = keywordRepository.save(
             new Keyword(null, "자바", "자바입니다", 1, 1, session_백엔드_레벨1.getId(), null, null));
-        session_백엔드_레벨1 = sessionRepository.save(new Session("백엔드Java 레벨1"));
 
         깃 = keywordRepository.save(
             new Keyword(null, "깃", "깃입니다", 2, 2, session_백엔드_레벨1.getId(), null, null));
-        session_백엔드_레벨1 = sessionRepository.save(new Session("백엔드Java 레벨1"));
 
         자바_질문1 = quizRepository.save(new Quiz(자바, "자바의 아버지는 제임스 고슬링일까요 ? 제이슨일까요 ?"));
         자바_질문2 = quizRepository.save(new Quiz(자바, "Stream 은 자바 몇 버전부터 지원했을까요?"));
@@ -61,6 +71,19 @@ class QuizRepositoryTest {
         final List<Quiz> expect = Arrays.asList(자바_질문1, 자바_질문2);
         final List<Quiz> actual = quizRepository.findFetchQuizByKeywordId(자바.getId());
 
-        Assertions.assertThat(actual).containsExactlyElementsOf(expect);
+        assertThat(actual).containsExactlyElementsOf(expect);
+    }
+
+    @DisplayName("커리큘럼 id 로 퀴즈 List 를 조회한다.")
+    @Test
+    void findQuizzesByCurriculum() {
+        // given
+        Long 백엔드_커리큘럼_Id = 백엔드.getId();
+
+        // when
+        List<CurriculumQuizResponse> acutal = quizRepository.findQuizzesByCurriculum(백엔드_커리큘럼_Id);
+
+        // then
+        assertThat(acutal).hasSize(3);
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

- #1607 

## 📝작업 내용

커리큘럼 별 퀴즈 검색 기능을 구현했습니다. 
중첩 Join 문을 사용했는데, 흐름이 curriculum -> session -> keyword -> quiz 순으로 진행하려 했고
그 이유는 드라이빙 테이블의 컬럼을 줄이기 위해서입니다.
Join 과정에서 session 이 curriculum에 대한 인덱스가 없어 풀테이블 스캔을 하는데 session 의 경우 사용하지 않을 데이터면서 데이터가 그렇게 많이 생길 것 같지도 않기에 인덱스는 생략했습니다
