### PR TITLE
로드맵 서비스 로직 리팩토링

### DIFF
--- a/backend/src/main/java/wooteco/prolog/roadmap/application/KeywordService.java
+++ b/backend/src/main/java/wooteco/prolog/roadmap/application/KeywordService.java
@@ -13,6 +13,7 @@ import wooteco.prolog.session.domain.repository.SessionRepository;
 
 import java.util.List;
 
+import static java.util.Collections.emptyMap;
 import static wooteco.prolog.common.exception.BadRequestCode.ROADMAP_KEYWORD_NOT_FOUND_EXCEPTION;
 import static wooteco.prolog.common.exception.BadRequestCode.ROADMAP_SESSION_NOT_FOUND_EXCEPTION;
 
@@ -66,7 +67,7 @@ public class KeywordService {
 
         Keyword keyword = keywordRepository.findFetchByIdOrderBySeq(keywordId);
 
-        return KeywordResponse.createWithAllChildResponse(keyword);
+        return KeywordResponse.createWithAllChildResponse(keyword, emptyMap(), emptyMap());
     }
 
     @Transactional(readOnly = true)
@@ -75,7 +76,7 @@ public class KeywordService {
 
         Keyword keyword = keywordRepository.findFetchByIdOrderBySeq(keywordId);
 
-        return KeywordResponse.createWithAllChildResponse(keyword);
+        return KeywordResponse.createWithAllChildResponse(keyword, emptyMap(), emptyMap());
     }
 
     @Transactional(readOnly = true)
@@ -84,14 +85,14 @@ public class KeywordService {
 
         List<Keyword> keywords = keywordRepository.findBySessionIdAndParentIsNull(sessionId);
 
-        return KeywordsResponse.from(keywords);
+        return KeywordsResponse.of(keywords, emptyMap(), emptyMap());
     }
 
     @Transactional(readOnly = true)
     public KeywordsResponse newFindSessionIncludeRootKeywords() {
         List<Keyword> keywords = keywordRepository.newFindByParentIsNull();
 
-        return KeywordsResponse.from(keywords);
+        return KeywordsResponse.of(keywords, emptyMap(), emptyMap());
     }
 
     public void updateKeyword(

--- a/backend/src/main/java/wooteco/prolog/roadmap/application/KeywordService.java
+++ b/backend/src/main/java/wooteco/prolog/roadmap/application/KeywordService.java
@@ -84,14 +84,14 @@ public class KeywordService {
 
         List<Keyword> keywords = keywordRepository.findBySessionIdAndParentIsNull(sessionId);
 
-        return KeywordsResponse.of(keywords);
+        return KeywordsResponse.from(keywords);
     }
 
     @Transactional(readOnly = true)
     public KeywordsResponse newFindSessionIncludeRootKeywords() {
         List<Keyword> keywords = keywordRepository.newFindByParentIsNull();
 
-        return KeywordsResponse.of(keywords);
+        return KeywordsResponse.from(keywords);
     }
 
     public void updateKeyword(

--- a/backend/src/main/java/wooteco/prolog/roadmap/application/KeywordService.java
+++ b/backend/src/main/java/wooteco/prolog/roadmap/application/KeywordService.java
@@ -1,9 +1,5 @@
 package wooteco.prolog.roadmap.application;
 
-import static wooteco.prolog.common.exception.BadRequestCode.ROADMAP_KEYWORD_NOT_FOUND_EXCEPTION;
-import static wooteco.prolog.common.exception.BadRequestCode.ROADMAP_SESSION_NOT_FOUND_EXCEPTION;
-
-import java.util.List;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import wooteco.prolog.common.exception.BadRequestException;
@@ -15,6 +11,11 @@ import wooteco.prolog.roadmap.domain.Keyword;
 import wooteco.prolog.roadmap.domain.repository.KeywordRepository;
 import wooteco.prolog.session.domain.repository.SessionRepository;
 
+import java.util.List;
+
+import static wooteco.prolog.common.exception.BadRequestCode.ROADMAP_KEYWORD_NOT_FOUND_EXCEPTION;
+import static wooteco.prolog.common.exception.BadRequestCode.ROADMAP_SESSION_NOT_FOUND_EXCEPTION;
+
 @Transactional
 @Service
 public class KeywordService {
@@ -23,7 +24,7 @@ public class KeywordService {
     private final KeywordRepository keywordRepository;
 
     public KeywordService(final SessionRepository sessionRepository,
-        final KeywordRepository keywordRepository) {
+                          final KeywordRepository keywordRepository) {
         this.sessionRepository = sessionRepository;
         this.keywordRepository = keywordRepository;
     }
@@ -83,14 +84,14 @@ public class KeywordService {
 
         List<Keyword> keywords = keywordRepository.findBySessionIdAndParentIsNull(sessionId);
 
-        return KeywordsResponse.createResponse(keywords);
+        return KeywordsResponse.of(keywords);
     }
 
     @Transactional(readOnly = true)
     public KeywordsResponse newFindSessionIncludeRootKeywords() {
         List<Keyword> keywords = keywordRepository.newFindByParentIsNull();
 
-        return KeywordsResponse.createResponse(keywords);
+        return KeywordsResponse.of(keywords);
     }
 
     public void updateKeyword(

--- a/backend/src/main/java/wooteco/prolog/roadmap/application/RoadMapService.java
+++ b/backend/src/main/java/wooteco/prolog/roadmap/application/RoadMapService.java
@@ -26,7 +26,7 @@ public class RoadMapService {
         final Map<Long, Integer> totalQuizCounts = getTotalQuizCounts();
         final Map<Long, Integer> answeredQuizCounts = getAnsweredQuizCounts(memberId);
 
-        final KeywordsResponse keywordsResponse = KeywordsResponse.of(keywords);
+        final KeywordsResponse keywordsResponse = KeywordsResponse.from(keywords);
         keywordsResponse.setProgress(totalQuizCounts, answeredQuizCounts);
 
         return keywordsResponse;

--- a/backend/src/main/java/wooteco/prolog/roadmap/application/RoadMapService.java
+++ b/backend/src/main/java/wooteco/prolog/roadmap/application/RoadMapService.java
@@ -6,7 +6,7 @@ import org.springframework.transaction.annotation.Transactional;
 import wooteco.prolog.roadmap.application.dto.KeywordsResponse;
 import wooteco.prolog.roadmap.domain.Keyword;
 import wooteco.prolog.roadmap.domain.repository.KeywordRepository;
-import wooteco.prolog.roadmap.domain.repository.dto.KeywordIdAndDoneQuizCount;
+import wooteco.prolog.roadmap.domain.repository.dto.KeywordIdAndAnsweredQuizCount;
 import wooteco.prolog.roadmap.domain.repository.dto.KeywordIdAndTotalQuizCount;
 
 import java.util.List;
@@ -24,10 +24,10 @@ public class RoadMapService {
     public KeywordsResponse findAllKeywordsWithProgress(final Long curriculumId, final Long memberId) {
         final List<Keyword> keywords = keywordRepository.findAllByCurriculumId(curriculumId);
         final Map<Long, Integer> totalQuizCounts = getTotalQuizCounts();
-        final Map<Long, Integer> doneQuizCounts = getDoneQuizCounts(memberId);
+        final Map<Long, Integer> answeredQuizCounts = getAnsweredQuizCounts(memberId);
 
         final KeywordsResponse keywordsResponse = KeywordsResponse.of(keywords);
-        keywordsResponse.setProgress(totalQuizCounts, doneQuizCounts);
+        keywordsResponse.setProgress(totalQuizCounts, answeredQuizCounts);
 
         return keywordsResponse;
     }
@@ -40,11 +40,11 @@ public class RoadMapService {
                     KeywordIdAndTotalQuizCount::getTotalQuizCount));
     }
 
-    private Map<Long, Integer> getDoneQuizCounts(final Long memberId) {
-        return keywordRepository.findDoneQuizCountByMemberId(memberId).stream()
+    private Map<Long, Integer> getAnsweredQuizCounts(final Long memberId) {
+        return keywordRepository.findAnsweredQuizCountByMemberId(memberId).stream()
             .collect(
                 toMap(
-                    KeywordIdAndDoneQuizCount::getKeywordId,
-                    KeywordIdAndDoneQuizCount::getDoneQuizCount));
+                    KeywordIdAndAnsweredQuizCount::getKeywordId,
+                    KeywordIdAndAnsweredQuizCount::getAnsweredQuizCount));
     }
 }

--- a/backend/src/main/java/wooteco/prolog/roadmap/application/RoadMapService.java
+++ b/backend/src/main/java/wooteco/prolog/roadmap/application/RoadMapService.java
@@ -1,122 +1,58 @@
 package wooteco.prolog.roadmap.application;
 
-import java.util.Comparator;
-import java.util.HashSet;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import wooteco.prolog.common.exception.BadRequestException;
-import wooteco.prolog.roadmap.application.dto.KeywordResponse;
 import wooteco.prolog.roadmap.application.dto.KeywordsResponse;
-import wooteco.prolog.roadmap.application.dto.RecommendedPostResponse;
-import wooteco.prolog.roadmap.domain.Curriculum;
-import wooteco.prolog.roadmap.domain.EssayAnswer;
 import wooteco.prolog.roadmap.domain.Keyword;
-import wooteco.prolog.roadmap.domain.Quiz;
-import wooteco.prolog.roadmap.domain.repository.CurriculumRepository;
-import wooteco.prolog.roadmap.domain.repository.EssayAnswerRepository;
 import wooteco.prolog.roadmap.domain.repository.KeywordRepository;
-import wooteco.prolog.roadmap.domain.repository.QuizRepository;
-import wooteco.prolog.session.domain.Session;
-import wooteco.prolog.session.domain.repository.SessionRepository;
+import wooteco.prolog.roadmap.domain.repository.dto.KeywordIdAndDoneQuizCount;
+import wooteco.prolog.roadmap.domain.repository.dto.KeywordIdAndTotalQuizCount;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
-import static java.util.stream.Collectors.groupingBy;
-import static java.util.stream.Collectors.toList;
-import static java.util.stream.Collectors.toSet;
-import static wooteco.prolog.common.exception.BadRequestCode.CURRICULUM_NOT_FOUND_EXCEPTION;
+import static java.util.Objects.isNull;
 
 @RequiredArgsConstructor
-@Transactional
+@Transactional(readOnly = true)
 @Service
 public class RoadMapService {
 
-    private final CurriculumRepository curriculumRepository;
-    private final SessionRepository sessionRepository;
     private final KeywordRepository keywordRepository;
-    private final QuizRepository quizRepository;
-    private final EssayAnswerRepository essayAnswerRepository;
 
-    @Transactional(readOnly = true)
     public KeywordsResponse findAllKeywordsWithProgress(final Long curriculumId, final Long memberId) {
-        final Curriculum curriculum = curriculumRepository.findById(curriculumId)
-            .orElseThrow(() -> new BadRequestException(CURRICULUM_NOT_FOUND_EXCEPTION));
+        final List<Keyword> keywords = keywordRepository.findAllByCurriculumId(curriculumId);
+        final Map<Long, Integer> totalQuizCounts = getTotalQuizCounts();
+        final Map<Long, Integer> doneQuizCounts = getDoneQuizCounts(memberId);
 
-        final List<Keyword> keywordsInCurriculum = getKeywordsInCurriculum(curriculum);
+        final KeywordsResponse keywordsResponse = KeywordsResponse.of(keywords);
+        keywordsResponse.setProgress(totalQuizCounts, doneQuizCounts);
 
-        final Map<Keyword, Set<Quiz>> quizzesInKeywords = quizRepository.findAll().stream()
-            .collect(groupingBy(Quiz::getKeyword, toSet()));
-
-        return createResponsesWithProgress(keywordsInCurriculum, quizzesInKeywords, getDoneQuizzes(memberId));
+        return keywordsResponse;
     }
 
-    private Set<Quiz> getDoneQuizzes(final Long memberId) {
-        return essayAnswerRepository.findAllByMemberId(memberId).stream()
-            .map(EssayAnswer::getQuiz)
-            .collect(toSet());
+    private Map<Long, Integer> getTotalQuizCounts() {
+        final Map<Long, Integer> totalQuizCounts = new HashMap<>();
+
+        for (KeywordIdAndTotalQuizCount totalQuizCount : keywordRepository.findTotalQuizCount()) {
+            totalQuizCounts.put(totalQuizCount.getKeywordId(), totalQuizCount.getTotalQuizCount());
+        }
+
+        return totalQuizCounts;
     }
 
-    private List<Keyword> getKeywordsInCurriculum(final Curriculum curriculum) {
-        final Set<Long> sessionIds = sessionRepository.findAllByCurriculumId(curriculum.getId())
-            .stream()
-            .map(Session::getId)
-            .collect(toSet());
+    private Map<Long, Integer> getDoneQuizCounts(final Long memberId) {
+        final Map<Long, Integer> doneQuizCounts = new HashMap<>();
+        if (isNull(memberId)) {
+            return doneQuizCounts;
+        }
 
-        return keywordRepository.findBySessionIdIn(sessionIds);
-    }
+        for (KeywordIdAndDoneQuizCount doneQuizCount : keywordRepository.findDoneQuizCountByMemberId(memberId)) {
+            doneQuizCounts.put(doneQuizCount.getKeywordId(), doneQuizCount.getDoneQuizCount());
+        }
 
-    private KeywordsResponse createResponsesWithProgress(final List<Keyword> keywords,
-                                                         final Map<Keyword, Set<Quiz>> quizzesPerKeyword,
-                                                         final Set<Quiz> doneQuizzes) {
-        final List<KeywordResponse> keywordResponses = keywords.stream()
-            .filter(Keyword::isRoot)
-            .map(keyword -> createResponseWithProgress(keyword, quizzesPerKeyword, doneQuizzes))
-            .sorted(Comparator.comparing(KeywordResponse::getKeywordId))
-            .collect(toList());
-
-        return new KeywordsResponse(keywordResponses);
-    }
-
-    private KeywordResponse createResponseWithProgress(final Keyword keyword,
-                                                       final Map<Keyword, Set<Quiz>> quizzesPerKeyword,
-                                                       final Set<Quiz> doneQuizzes) {
-        final int totalQuizCount = quizzesPerKeyword.getOrDefault(keyword, new HashSet<>()).size();
-        final int doneQuizCount = getDoneQuizCount(
-            quizzesPerKeyword.getOrDefault(keyword, new HashSet<>()), doneQuizzes);
-
-        final List<RecommendedPostResponse> recommendedPostResponses = keyword.getRecommendedPosts().stream()
-            .map(RecommendedPostResponse::from)
-            .collect(toList());
-
-        return new KeywordResponse(
-            keyword.getId(),
-            keyword.getName(),
-            keyword.getDescription(),
-            keyword.getSeq(),
-            keyword.getImportance(),
-            totalQuizCount,
-            doneQuizCount,
-            keyword.getParentIdOrNull(),
-            recommendedPostResponses,
-            createChildrenWithProgress(keyword.getChildren(), quizzesPerKeyword, doneQuizzes)
-        );
-    }
-
-    private int getDoneQuizCount(final Set<Quiz> quizzes, final Set<Quiz> doneQuizzes) {
-        quizzes.retainAll(doneQuizzes);
-        return quizzes.size();
-    }
-
-    private List<KeywordResponse> createChildrenWithProgress(final Set<Keyword> children,
-                                                            final Map<Keyword, Set<Quiz>> quizzesPerKeyword,
-                                                            final Set<Quiz> userAnswers) {
-        return children.stream()
-            .map(child -> createResponseWithProgress(child, quizzesPerKeyword, userAnswers))
-            .sorted(Comparator.comparing(KeywordResponse::getKeywordId))
-            .collect(Collectors.toList());
+        return doneQuizCounts;
     }
 }

--- a/backend/src/main/java/wooteco/prolog/roadmap/application/RoadMapService.java
+++ b/backend/src/main/java/wooteco/prolog/roadmap/application/RoadMapService.java
@@ -26,10 +26,7 @@ public class RoadMapService {
         final Map<Long, Integer> totalQuizCounts = getTotalQuizCounts();
         final Map<Long, Integer> answeredQuizCounts = getAnsweredQuizCounts(memberId);
 
-        final KeywordsResponse keywordsResponse = KeywordsResponse.from(keywords);
-        keywordsResponse.setProgress(totalQuizCounts, answeredQuizCounts);
-
-        return keywordsResponse;
+        return KeywordsResponse.of(keywords, totalQuizCounts, answeredQuizCounts);
     }
 
     private Map<Long, Integer> getTotalQuizCounts() {

--- a/backend/src/main/java/wooteco/prolog/roadmap/application/RoadMapService.java
+++ b/backend/src/main/java/wooteco/prolog/roadmap/application/RoadMapService.java
@@ -9,11 +9,10 @@ import wooteco.prolog.roadmap.domain.repository.KeywordRepository;
 import wooteco.prolog.roadmap.domain.repository.dto.KeywordIdAndDoneQuizCount;
 import wooteco.prolog.roadmap.domain.repository.dto.KeywordIdAndTotalQuizCount;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static java.util.Objects.isNull;
+import static java.util.stream.Collectors.toMap;
 
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -34,25 +33,18 @@ public class RoadMapService {
     }
 
     private Map<Long, Integer> getTotalQuizCounts() {
-        final Map<Long, Integer> totalQuizCounts = new HashMap<>();
-
-        for (KeywordIdAndTotalQuizCount totalQuizCount : keywordRepository.findTotalQuizCount()) {
-            totalQuizCounts.put(totalQuizCount.getKeywordId(), totalQuizCount.getTotalQuizCount());
-        }
-
-        return totalQuizCounts;
+        return keywordRepository.findTotalQuizCount().stream()
+            .collect(
+                toMap(
+                    KeywordIdAndTotalQuizCount::getKeywordId,
+                    KeywordIdAndTotalQuizCount::getTotalQuizCount));
     }
 
     private Map<Long, Integer> getDoneQuizCounts(final Long memberId) {
-        final Map<Long, Integer> doneQuizCounts = new HashMap<>();
-        if (isNull(memberId)) {
-            return doneQuizCounts;
-        }
-
-        for (KeywordIdAndDoneQuizCount doneQuizCount : keywordRepository.findDoneQuizCountByMemberId(memberId)) {
-            doneQuizCounts.put(doneQuizCount.getKeywordId(), doneQuizCount.getDoneQuizCount());
-        }
-
-        return doneQuizCounts;
+        return keywordRepository.findDoneQuizCountByMemberId(memberId).stream()
+            .collect(
+                toMap(
+                    KeywordIdAndDoneQuizCount::getKeywordId,
+                    KeywordIdAndDoneQuizCount::getDoneQuizCount));
     }
 }

--- a/backend/src/main/java/wooteco/prolog/roadmap/application/dto/KeywordResponse.java
+++ b/backend/src/main/java/wooteco/prolog/roadmap/application/dto/KeywordResponse.java
@@ -1,13 +1,12 @@
 package wooteco.prolog.roadmap.application.dto;
 
-import java.util.ArrayList;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import wooteco.prolog.roadmap.domain.Keyword;
 
-import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -56,12 +55,6 @@ public class KeywordResponse {
             null);
     }
 
-    private static List<RecommendedPostResponse> createRecommendedPostResponses(final Keyword keyword) {
-        return keyword.getRecommendedPosts().stream()
-            .map(RecommendedPostResponse::from)
-            .collect(Collectors.toList());
-    }
-
     public static KeywordResponse createWithAllChildResponse(final Keyword keyword) {
         return new KeywordResponse(
             keyword.getId(),
@@ -76,11 +69,22 @@ public class KeywordResponse {
             createChildren(keyword.getChildren()));
     }
 
+    private static List<RecommendedPostResponse> createRecommendedPostResponses(final Keyword keyword) {
+        return keyword.getRecommendedPosts().stream()
+            .map(RecommendedPostResponse::from)
+            .collect(Collectors.toList());
+    }
+
     private static List<KeywordResponse> createChildren(final Set<Keyword> children) {
-        List<KeywordResponse> keywords = new ArrayList<>();
-        for (Keyword keyword : children) {
-            keywords.add(createWithAllChildResponse(keyword));
-        }
-        return keywords;
+        return children.stream()
+            .map(KeywordResponse::createWithAllChildResponse)
+            .collect(Collectors.toList());
+    }
+
+    public void setProgress(final Map<Long, Integer> totalQuizCounts, final Map<Long, Integer> doneQuizCounts) {
+        totalQuizCount = totalQuizCounts.getOrDefault(keywordId, 0);
+        doneQuizCount = doneQuizCounts.getOrDefault(keywordId, 0);
+
+        childrenKeywords.forEach(child -> child.setProgress(totalQuizCounts, doneQuizCounts));
     }
 }

--- a/backend/src/main/java/wooteco/prolog/roadmap/application/dto/KeywordResponse.java
+++ b/backend/src/main/java/wooteco/prolog/roadmap/application/dto/KeywordResponse.java
@@ -81,10 +81,10 @@ public class KeywordResponse {
             .collect(Collectors.toList());
     }
 
-    public void setProgress(final Map<Long, Integer> totalQuizCounts, final Map<Long, Integer> doneQuizCounts) {
+    public void setProgress(final Map<Long, Integer> totalQuizCounts, final Map<Long, Integer> answeredQuizCounts) {
         totalQuizCount = totalQuizCounts.getOrDefault(keywordId, 0);
-        doneQuizCount = doneQuizCounts.getOrDefault(keywordId, 0);
+        doneQuizCount = answeredQuizCounts.getOrDefault(keywordId, 0);
 
-        childrenKeywords.forEach(child -> child.setProgress(totalQuizCounts, doneQuizCounts));
+        childrenKeywords.forEach(child -> child.setProgress(totalQuizCounts, answeredQuizCounts));
     }
 }

--- a/backend/src/main/java/wooteco/prolog/roadmap/application/dto/KeywordsResponse.java
+++ b/backend/src/main/java/wooteco/prolog/roadmap/application/dto/KeywordsResponse.java
@@ -1,11 +1,13 @@
 package wooteco.prolog.roadmap.application.dto;
 
-import java.util.List;
-import java.util.stream.Collectors;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import wooteco.prolog.roadmap.domain.Keyword;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
@@ -17,18 +19,16 @@ public class KeywordsResponse {
         this.data = data;
     }
 
-    public static KeywordsResponse createResponse(final List<Keyword> keywords) {
-        List<KeywordResponse> keywordsResponse = keywords.stream()
-            .map(KeywordResponse::createResponse)
-            .collect(Collectors.toList());
-        return new KeywordsResponse(keywordsResponse);
-    }
-
-    public static KeywordsResponse createResponseWithChildren(final List<Keyword> keywords) {
-        List<KeywordResponse> keywordsResponse = keywords.stream()
+    public static KeywordsResponse of(final List<Keyword> keywords) {
+        final List<KeywordResponse> keywordsResponse = keywords.stream()
             .filter(Keyword::isRoot)
             .map(KeywordResponse::createWithAllChildResponse)
             .collect(Collectors.toList());
+
         return new KeywordsResponse(keywordsResponse);
+    }
+
+    public void setProgress(final Map<Long, Integer> totalQuizCounts, final Map<Long, Integer> doneQuizCounts) {
+        data.forEach(response -> response.setProgress(totalQuizCounts, doneQuizCounts));
     }
 }

--- a/backend/src/main/java/wooteco/prolog/roadmap/application/dto/KeywordsResponse.java
+++ b/backend/src/main/java/wooteco/prolog/roadmap/application/dto/KeywordsResponse.java
@@ -28,7 +28,7 @@ public class KeywordsResponse {
         return new KeywordsResponse(keywordsResponse);
     }
 
-    public void setProgress(final Map<Long, Integer> totalQuizCounts, final Map<Long, Integer> doneQuizCounts) {
-        data.forEach(response -> response.setProgress(totalQuizCounts, doneQuizCounts));
+    public void setProgress(final Map<Long, Integer> totalQuizCounts, final Map<Long, Integer> answeredQuizCounts) {
+        data.forEach(response -> response.setProgress(totalQuizCounts, answeredQuizCounts));
     }
 }

--- a/backend/src/main/java/wooteco/prolog/roadmap/application/dto/KeywordsResponse.java
+++ b/backend/src/main/java/wooteco/prolog/roadmap/application/dto/KeywordsResponse.java
@@ -19,16 +19,14 @@ public class KeywordsResponse {
         this.data = data;
     }
 
-    public static KeywordsResponse from(final List<Keyword> keywords) {
+    public static KeywordsResponse of(final List<Keyword> keywords,
+                                      final Map<Long, Integer> totalQuizCounts,
+                                      final Map<Long, Integer> answeredQuizCounts) {
         final List<KeywordResponse> keywordsResponse = keywords.stream()
             .filter(Keyword::isRoot)
-            .map(KeywordResponse::createWithAllChildResponse)
+            .map(rootKeyword -> KeywordResponse.createWithAllChildResponse(rootKeyword, totalQuizCounts, answeredQuizCounts))
             .collect(Collectors.toList());
 
         return new KeywordsResponse(keywordsResponse);
-    }
-
-    public void setProgress(final Map<Long, Integer> totalQuizCounts, final Map<Long, Integer> answeredQuizCounts) {
-        data.forEach(response -> response.setProgress(totalQuizCounts, answeredQuizCounts));
     }
 }

--- a/backend/src/main/java/wooteco/prolog/roadmap/application/dto/KeywordsResponse.java
+++ b/backend/src/main/java/wooteco/prolog/roadmap/application/dto/KeywordsResponse.java
@@ -19,7 +19,7 @@ public class KeywordsResponse {
         this.data = data;
     }
 
-    public static KeywordsResponse of(final List<Keyword> keywords) {
+    public static KeywordsResponse from(final List<Keyword> keywords) {
         final List<KeywordResponse> keywordsResponse = keywords.stream()
             .filter(Keyword::isRoot)
             .map(KeywordResponse::createWithAllChildResponse)

--- a/backend/src/main/java/wooteco/prolog/roadmap/domain/Keyword.java
+++ b/backend/src/main/java/wooteco/prolog/roadmap/domain/Keyword.java
@@ -7,7 +7,16 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.BatchSize;
 import wooteco.prolog.common.exception.BadRequestException;
 
-import javax.persistence.*;
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
@@ -38,6 +47,7 @@ public class Keyword {
     @Column(name = "session_id", nullable = false)
     private Long sessionId;
 
+    @BatchSize(size = 1000)
     @OneToMany(mappedBy = "keyword", cascade = CascadeType.ALL, orphanRemoval = true)
     private Set<RecommendedPost> recommendedPosts = new HashSet<>();
 
@@ -50,8 +60,7 @@ public class Keyword {
     private Set<Keyword> children = new HashSet<>();
 
     public Keyword(final Long id, final String name, final String description, final int seq,
-                   final int importance,
-                   final Long sessionId, final Keyword parent, final Set<Keyword> children) {
+                   final int importance, final Long sessionId, final Keyword parent, final Set<Keyword> children) {
         validateSeq(seq);
         this.id = id;
         this.name = name;
@@ -69,7 +78,7 @@ public class Keyword {
                                         final int importance,
                                         final Long sessionId,
                                         final Keyword parent) {
-        return new Keyword(null, name, description, seq, importance, sessionId, parent, null);
+        return new Keyword(null, name, description, seq, importance, sessionId, parent, new HashSet<>());
     }
 
     public void update(final String name, final String description, final int seq,

--- a/backend/src/main/java/wooteco/prolog/roadmap/domain/repository/KeywordRepository.java
+++ b/backend/src/main/java/wooteco/prolog/roadmap/domain/repository/KeywordRepository.java
@@ -39,7 +39,6 @@ public interface KeywordRepository extends JpaRepository<Keyword, Long> {
 
     @Query("SELECT k FROM Keyword k " +
         "JOIN Session s ON s.id = k.sessionId " +
-        "LEFT JOIN FETCH RecommendedPost r ON r.keyword.id = k.id " +
         "WHERE s.curriculumId = :curriculumId ")
     List<Keyword> findAllByCurriculumId(Long curriculumId);
 }

--- a/backend/src/main/java/wooteco/prolog/roadmap/domain/repository/KeywordRepository.java
+++ b/backend/src/main/java/wooteco/prolog/roadmap/domain/repository/KeywordRepository.java
@@ -4,7 +4,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import wooteco.prolog.roadmap.domain.Keyword;
-import wooteco.prolog.roadmap.domain.repository.dto.KeywordIdAndDoneQuizCount;
+import wooteco.prolog.roadmap.domain.repository.dto.KeywordIdAndAnsweredQuizCount;
 import wooteco.prolog.roadmap.domain.repository.dto.KeywordIdAndTotalQuizCount;
 
 import java.util.List;
@@ -17,13 +17,13 @@ public interface KeywordRepository extends JpaRepository<Keyword, Long> {
         "GROUP BY k.id")
     List<KeywordIdAndTotalQuizCount> findTotalQuizCount();
 
-    @Query("SELECT k.id AS keywordId, COUNT (e.id) AS doneQuizCount " +
+    @Query("SELECT k.id AS keywordId, COUNT (e.id) AS answeredQuizCount " +
         "FROM Keyword k " +
         "JOIN Quiz q ON k.id = q.keyword.id " +
         "JOIN EssayAnswer e ON e.quiz.id = q.id " +
         "WHERE e.member.id = :memberId " +
         "GROUP BY k.id ")
-    List<KeywordIdAndDoneQuizCount> findDoneQuizCountByMemberId(@Param("memberId") Long memberId);
+    List<KeywordIdAndAnsweredQuizCount> findAnsweredQuizCountByMemberId(@Param("memberId") Long memberId);
 
     Keyword findFetchByIdOrderBySeq(@Param("keywordId") Long keywordId);
 

--- a/backend/src/main/java/wooteco/prolog/roadmap/domain/repository/QuizRepository.java
+++ b/backend/src/main/java/wooteco/prolog/roadmap/domain/repository/QuizRepository.java
@@ -1,11 +1,12 @@
 package wooteco.prolog.roadmap.domain.repository;
 
-import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import wooteco.prolog.roadmap.application.dto.CurriculumQuizResponse;
 import wooteco.prolog.roadmap.domain.Quiz;
+
+import java.util.List;
 
 public interface QuizRepository extends JpaRepository<Quiz, Long> {
 

--- a/backend/src/main/java/wooteco/prolog/roadmap/domain/repository/dto/KeywordIdAndAnsweredQuizCount.java
+++ b/backend/src/main/java/wooteco/prolog/roadmap/domain/repository/dto/KeywordIdAndAnsweredQuizCount.java
@@ -1,7 +1,7 @@
 package wooteco.prolog.roadmap.domain.repository.dto;
 
-public interface KeywordIdAndDoneQuizCount {
+public interface KeywordIdAndAnsweredQuizCount {
     long getKeywordId();
 
-    int getDoneQuizCount();
+    int getAnsweredQuizCount();
 }

--- a/backend/src/main/java/wooteco/prolog/roadmap/domain/repository/dto/KeywordIdAndDoneQuizCount.java
+++ b/backend/src/main/java/wooteco/prolog/roadmap/domain/repository/dto/KeywordIdAndDoneQuizCount.java
@@ -1,0 +1,7 @@
+package wooteco.prolog.roadmap.domain.repository.dto;
+
+public interface KeywordIdAndDoneQuizCount {
+    long getKeywordId();
+
+    int getDoneQuizCount();
+}

--- a/backend/src/main/java/wooteco/prolog/roadmap/domain/repository/dto/KeywordIdAndTotalQuizCount.java
+++ b/backend/src/main/java/wooteco/prolog/roadmap/domain/repository/dto/KeywordIdAndTotalQuizCount.java
@@ -1,0 +1,7 @@
+package wooteco.prolog.roadmap.domain.repository.dto;
+
+public interface KeywordIdAndTotalQuizCount {
+    long getKeywordId();
+
+    int getTotalQuizCount();
+}

--- a/backend/src/test/java/wooteco/prolog/roadmap/application/RecommendedPostServiceTest.java
+++ b/backend/src/test/java/wooteco/prolog/roadmap/application/RecommendedPostServiceTest.java
@@ -17,7 +17,6 @@ import wooteco.prolog.session.domain.Session;
 import wooteco.prolog.session.domain.repository.SessionRepository;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 @SpringBootTest
 class RecommendedPostServiceTest {
@@ -90,10 +89,6 @@ class RecommendedPostServiceTest {
         recommendedPostService.delete(recommendedPostId);
 
         //then
-        assertSoftly(softAssertions -> {
-            assertThat(recommendedPostRepository.findAll()).hasSize(0);
-            assertThat(keywordRepository.findById(keyword.getId()).get().getRecommendedPosts())
-                .isEmpty();
-        });
+        assertThat(recommendedPostRepository.existsById(recommendedPostId)).isFalse();
     }
 }

--- a/backend/src/test/java/wooteco/prolog/roadmap/application/RoadMapServiceTest.java
+++ b/backend/src/test/java/wooteco/prolog/roadmap/application/RoadMapServiceTest.java
@@ -1,92 +1,202 @@
 package wooteco.prolog.roadmap.application;
 
+import org.assertj.core.api.AbstractListAssert;
+import org.assertj.core.api.ObjectAssert;
+import org.assertj.core.api.ProxyableListAssert;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import wooteco.prolog.common.DataInitializer;
 import wooteco.prolog.member.domain.Member;
 import wooteco.prolog.member.domain.Role;
+import wooteco.prolog.member.domain.repository.MemberRepository;
 import wooteco.prolog.roadmap.application.dto.KeywordResponse;
 import wooteco.prolog.roadmap.application.dto.KeywordsResponse;
-import wooteco.prolog.roadmap.domain.Curriculum;
 import wooteco.prolog.roadmap.domain.EssayAnswer;
 import wooteco.prolog.roadmap.domain.Keyword;
 import wooteco.prolog.roadmap.domain.Quiz;
-import wooteco.prolog.roadmap.domain.repository.CurriculumRepository;
 import wooteco.prolog.roadmap.domain.repository.EssayAnswerRepository;
 import wooteco.prolog.roadmap.domain.repository.KeywordRepository;
 import wooteco.prolog.roadmap.domain.repository.QuizRepository;
 import wooteco.prolog.session.domain.Session;
 import wooteco.prolog.session.domain.repository.SessionRepository;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Optional;
+import java.util.function.Consumer;
 
+import static java.util.Collections.emptySet;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.Mockito.when;
 
-@ExtendWith(MockitoExtension.class)
+@SpringBootTest
 class RoadMapServiceTest {
 
-    @Mock
-    private CurriculumRepository curriculumRepository;
-    @Mock
+    @Autowired
     private SessionRepository sessionRepository;
-    @Mock
+    @Autowired
     private KeywordRepository keywordRepository;
-    @Mock
+    @Autowired
     private QuizRepository quizRepository;
-    @Mock
+    @Autowired
     private EssayAnswerRepository essayAnswerRepository;
-    @InjectMocks
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
     private RoadMapService roadMapService;
 
+    @Autowired
+    private DataInitializer dataInitializer;
+
+    @AfterEach
+    void truncate() {
+        dataInitializer.execute();
+    }
+
     @Test
-    @DisplayName("curriculumId가 주어지면 해당 커리큘럼의 키워드들을 학습 진도와 함께 전부 조회할 수 있다.")
+    @DisplayName("커리큘럼 ID에 해당하는 모든 키워드를 진도율과 함께 조회할 수 있다 - 비회원")
     void findAllKeywordsWithProgress() {
         //given
-        final Curriculum curriculum = new Curriculum(1L, "커리큘럼1");
-        final Session session = new Session(1L, curriculum.getId(), "세션1");
-        final List<Session> sessions = Arrays.asList(session);
-        final Keyword keyword = new Keyword(1L, "자바1", "자바 설명1", 1, 5, session.getId(),
-            null, Collections.emptySet());
-        final Quiz quiz = new Quiz(1L, keyword, "자바8을 왜 쓰나요?");
-        final Member member = new Member(1L, "연어", "참치", Role.CREW, 1L, "image");
-        final EssayAnswer essayAnswer = new EssayAnswer(quiz, "쓰라고 해서요ㅠㅠ", member);
+        final Long curriculumId = 1L;
+        final Long session1 = createSession(curriculumId);
+        final Long session2 = createSession(curriculumId);
 
-        when(curriculumRepository.findById(anyLong()))
-            .thenReturn(Optional.of(curriculum));
+        final Keyword root1 = createParentKeyword("스트림", "스트림 API 설명", session1);
+        final Keyword root2 = createParentKeyword("컬렉션", "컬렉션 API 설명", session2);
 
-        when(sessionRepository.findAllByCurriculumId(anyLong()))
-            .thenReturn(sessions);
+        final Keyword oneDepthChild = createChildKeyword(root1, "map()", "스트림 api의 map");
+        final Keyword twoDepthChild = createChildKeyword(oneDepthChild, "map()의 파라미터", "파라미터 설명");
 
-        when(keywordRepository.findBySessionIdIn(any()))
-            .thenReturn(Arrays.asList(keyword));
-
-        when(essayAnswerRepository.findAllByMemberId(1L))
-            .thenReturn(new HashSet<>(Arrays.asList(essayAnswer)));
-
-        when(quizRepository.findAll())
-            .thenReturn(Arrays.asList(quiz));
+        createQuiz(oneDepthChild, "map을 왜 쓰나요?");
+        createQuiz(root2, "컬렉션을 왜 쓰나요?");
 
         //when
-        final KeywordsResponse actual =
-            roadMapService.findAllKeywordsWithProgress(curriculum.getId(), 1L);
+        final KeywordsResponse response = roadMapService.findAllKeywordsWithProgress(curriculumId, null);
 
         //then
-        final List<KeywordResponse> responses = actual.getData();
-        assertSoftly(soft -> {
-            assertThat(responses).hasSize(1);
-            assertThat(responses.get(0).getDoneQuizCount()).isOne();
-            assertThat(responses.get(0).getTotalQuizCount()).isOne();
+        assertSoftly(softAssertions -> {
+            final ProxyableListAssert<KeywordResponse> roots = softAssertions.assertThat(response.getData());
+            final AbstractListAssert<?, List<? extends KeywordResponse>, KeywordResponse, ObjectAssert<KeywordResponse>> oneDepthChildren
+                = roots.flatMap(KeywordResponse::getChildrenKeywords);
+            final AbstractListAssert<?, List<? extends KeywordResponse>, KeywordResponse, ObjectAssert<KeywordResponse>> twoDepthChildren
+                = oneDepthChildren.flatMap(KeywordResponse::getChildrenKeywords);
+
+            roots.hasSize(2)
+                .satisfies(containsKeywordIds(root1.getId(), root2.getId()))
+                .satisfies(containsTotalQuizCounts(0, 1))
+                .satisfies(containsDoneQuizCounts(0, 0));
+
+            oneDepthChildren.hasSize(1)
+                .satisfies(containsKeywordIds(oneDepthChild.getId()))
+                .satisfies(containsTotalQuizCounts(1))
+                .satisfies(containsDoneQuizCounts(0));
+
+            twoDepthChildren.hasSize(1)
+                .satisfies(containsKeywordIds(twoDepthChild.getId()))
+                .satisfies(containsTotalQuizCounts(0))
+                .satisfies(containsDoneQuizCounts(0));
         });
+    }
+
+    @Test
+    @DisplayName("커리큘럼 ID에 해당하는 모든 키워드를 진도율과 함께 조회할 수 있다 - 회원")
+    void findAllKeywordsWithProgress_login() {
+        //given
+        final Long curriculumId = 1L;
+        final Long session1 = createSession(curriculumId);
+        final Long session2 = createSession(curriculumId);
+
+        final Keyword root1 = createParentKeyword("스트림", "스트림 API 설명", session1);
+        final Keyword root2 = createParentKeyword("컬렉션", "컬렉션 API 설명", session2);
+
+        final Keyword oneDepthChild = createChildKeyword(root1, "map()", "스트림 api의 map");
+        final Keyword twoDepthChild = createChildKeyword(oneDepthChild, "map()의 파라미터", "파라미터 설명");
+
+        final Quiz quiz1 = createQuiz(root2, "컬렉션을 왜 쓰나요?");
+        final Quiz quiz2 = createQuiz(twoDepthChild, "파라미터의 종류는?");
+        createQuiz(oneDepthChild, "map을 왜 쓰나요?");
+
+        final Member member = createMember();
+
+        createEssayAnswer(quiz1, member, "배열을 쓸 수는 없으니까요");
+        createEssayAnswer(quiz2, member, "Function<? super 현재 타입, ?> 입니다");
+
+        //when
+        final KeywordsResponse response = roadMapService.findAllKeywordsWithProgress(curriculumId, member.getId());
+
+        //then
+        assertSoftly(softAssertions -> {
+            final ProxyableListAssert<KeywordResponse> roots = softAssertions.assertThat(response.getData());
+            final AbstractListAssert<?, List<? extends KeywordResponse>, KeywordResponse, ObjectAssert<KeywordResponse>> oneDepthChildren
+                = roots.flatMap(KeywordResponse::getChildrenKeywords);
+            final AbstractListAssert<?, List<? extends KeywordResponse>, KeywordResponse, ObjectAssert<KeywordResponse>> twoDepthChildren
+                = oneDepthChildren.flatMap(KeywordResponse::getChildrenKeywords);
+
+            roots.hasSize(2)
+                .satisfies(containsKeywordIds(root1.getId(), root2.getId()))
+                .satisfies(containsTotalQuizCounts(0, 1))
+                .satisfies(containsDoneQuizCounts(0, 1));
+
+            oneDepthChildren.hasSize(1)
+                .satisfies(containsKeywordIds(oneDepthChild.getId()))
+                .satisfies(containsTotalQuizCounts(1))
+                .satisfies(containsDoneQuizCounts(0));
+
+            twoDepthChildren.hasSize(1)
+                .satisfies(containsKeywordIds(twoDepthChild.getId()))
+                .satisfies(containsTotalQuizCounts(1))
+                .satisfies(containsDoneQuizCounts(1));
+        });
+    }
+
+    private Consumer<List<? extends KeywordResponse>> containsDoneQuizCounts(final Integer... expected) {
+        return keywords -> assertThat(keywords)
+            .map(KeywordResponse::getDoneQuizCount)
+            .containsExactlyInAnyOrder(expected);
+    }
+
+    private Consumer<List<? extends KeywordResponse>> containsTotalQuizCounts(final Integer... expected) {
+        return keywords -> assertThat(keywords)
+            .map(KeywordResponse::getTotalQuizCount)
+            .containsExactlyInAnyOrder(expected);
+    }
+
+    private Consumer<List<? extends KeywordResponse>> containsKeywordIds(final Long... expected) {
+        return keywords -> assertThat(keywords)
+            .map(KeywordResponse::getKeywordId)
+            .containsExactlyInAnyOrder(expected);
+    }
+
+    private Long createSession(final Long curriculumId) {
+        Session session = new Session(curriculumId, "테스트 세션");
+        sessionRepository.save(session);
+        return session.getId();
+    }
+
+    private Keyword createParentKeyword(final String name, final String description, final Long sessionId) {
+        final Keyword keyword = new Keyword(null, name, description, 1, 1, sessionId, null, emptySet());
+        return keywordRepository.save(keyword);
+    }
+
+    private Keyword createChildKeyword(final Keyword parent, final String name, final String description) {
+        final Keyword keyword = new Keyword(null, name, description, 1, 1, parent.getSessionId(), parent, emptySet());
+        return keywordRepository.save(keyword);
+    }
+
+    private Quiz createQuiz(final Keyword keyword, final String question) {
+        final Quiz quiz = new Quiz(keyword, question);
+        return quizRepository.save(quiz);
+    }
+
+    private Member createMember() {
+        final Member member = new Member("id", "연어", Role.CREW, 1L, "image");
+        return memberRepository.save(member);
+    }
+
+    private EssayAnswer createEssayAnswer(final Quiz quiz, final Member member, final String answer) {
+        final EssayAnswer essayAnswer = new EssayAnswer(quiz, answer, member);
+        return essayAnswerRepository.save(essayAnswer);
     }
 }

--- a/backend/src/test/java/wooteco/prolog/roadmap/application/RoadMapServiceTest.java
+++ b/backend/src/test/java/wooteco/prolog/roadmap/application/RoadMapServiceTest.java
@@ -153,7 +153,7 @@ class RoadMapServiceTest {
 
     private Consumer<List<? extends KeywordResponse>> containsAnsweredQuizCounts(final Integer... expected) {
         return keywords -> assertThat(keywords)
-            .map(KeywordResponse::getDoneQuizCount)
+            .map(KeywordResponse::getAnsweredQuizCount)
             .containsExactlyInAnyOrder(expected);
     }
 

--- a/backend/src/test/java/wooteco/prolog/roadmap/application/RoadMapServiceTest.java
+++ b/backend/src/test/java/wooteco/prolog/roadmap/application/RoadMapServiceTest.java
@@ -86,17 +86,17 @@ class RoadMapServiceTest {
             roots.hasSize(2)
                 .satisfies(containsKeywordIds(root1.getId(), root2.getId()))
                 .satisfies(containsTotalQuizCounts(0, 1))
-                .satisfies(containsDoneQuizCounts(0, 0));
+                .satisfies(containsAnsweredQuizCounts(0, 0));
 
             oneDepthChildren.hasSize(1)
                 .satisfies(containsKeywordIds(oneDepthChild.getId()))
                 .satisfies(containsTotalQuizCounts(1))
-                .satisfies(containsDoneQuizCounts(0));
+                .satisfies(containsAnsweredQuizCounts(0));
 
             twoDepthChildren.hasSize(1)
                 .satisfies(containsKeywordIds(twoDepthChild.getId()))
                 .satisfies(containsTotalQuizCounts(0))
-                .satisfies(containsDoneQuizCounts(0));
+                .satisfies(containsAnsweredQuizCounts(0));
         });
     }
 
@@ -137,21 +137,21 @@ class RoadMapServiceTest {
             roots.hasSize(2)
                 .satisfies(containsKeywordIds(root1.getId(), root2.getId()))
                 .satisfies(containsTotalQuizCounts(0, 1))
-                .satisfies(containsDoneQuizCounts(0, 1));
+                .satisfies(containsAnsweredQuizCounts(0, 1));
 
             oneDepthChildren.hasSize(1)
                 .satisfies(containsKeywordIds(oneDepthChild.getId()))
                 .satisfies(containsTotalQuizCounts(1))
-                .satisfies(containsDoneQuizCounts(0));
+                .satisfies(containsAnsweredQuizCounts(0));
 
             twoDepthChildren.hasSize(1)
                 .satisfies(containsKeywordIds(twoDepthChild.getId()))
                 .satisfies(containsTotalQuizCounts(1))
-                .satisfies(containsDoneQuizCounts(1));
+                .satisfies(containsAnsweredQuizCounts(1));
         });
     }
 
-    private Consumer<List<? extends KeywordResponse>> containsDoneQuizCounts(final Integer... expected) {
+    private Consumer<List<? extends KeywordResponse>> containsAnsweredQuizCounts(final Integer... expected) {
         return keywords -> assertThat(keywords)
             .map(KeywordResponse::getDoneQuizCount)
             .containsExactlyInAnyOrder(expected);

--- a/backend/src/test/java/wooteco/prolog/roadmap/repository/KeywordRepositoryTest.java
+++ b/backend/src/test/java/wooteco/prolog/roadmap/repository/KeywordRepositoryTest.java
@@ -14,7 +14,7 @@ import wooteco.prolog.roadmap.domain.repository.CurriculumRepository;
 import wooteco.prolog.roadmap.domain.repository.EssayAnswerRepository;
 import wooteco.prolog.roadmap.domain.repository.KeywordRepository;
 import wooteco.prolog.roadmap.domain.repository.QuizRepository;
-import wooteco.prolog.roadmap.domain.repository.dto.KeywordIdAndDoneQuizCount;
+import wooteco.prolog.roadmap.domain.repository.dto.KeywordIdAndAnsweredQuizCount;
 import wooteco.prolog.roadmap.domain.repository.dto.KeywordIdAndTotalQuizCount;
 import wooteco.prolog.session.domain.Session;
 import wooteco.prolog.session.domain.repository.SessionRepository;
@@ -121,7 +121,7 @@ class KeywordRepositoryTest {
             sessionId);
 
         // then
-        assertThat(extractParentKeyword.size()).isEqualTo(1);
+        assertThat(extractParentKeyword).hasSize(1);
     }
 
     @Test
@@ -219,15 +219,15 @@ class KeywordRepositoryTest {
         essayAnswerRepository.save(new EssayAnswer(quiz2, "쓰라고 해서요ㅠ", member));
 
         //when
-        final List<KeywordIdAndDoneQuizCount> doneQuizCounts = keywordRepository.findDoneQuizCountByMemberId(member.getId());
+        final List<KeywordIdAndAnsweredQuizCount> doneQuizCounts = keywordRepository.findAnsweredQuizCountByMemberId(member.getId());
 
         //then
         assertSoftly(softAssertions -> {
             softAssertions.assertThat(doneQuizCounts)
-                .map(KeywordIdAndDoneQuizCount::getKeywordId)
+                .map(KeywordIdAndAnsweredQuizCount::getKeywordId)
                 .containsExactly(parent.getId());
             softAssertions.assertThat(doneQuizCounts)
-                .map(KeywordIdAndDoneQuizCount::getDoneQuizCount)
+                .map(KeywordIdAndAnsweredQuizCount::getAnsweredQuizCount)
                 .containsExactly(2);
         });
     }

--- a/backend/src/test/java/wooteco/prolog/roadmap/repository/KeywordRepositoryTest.java
+++ b/backend/src/test/java/wooteco/prolog/roadmap/repository/KeywordRepositoryTest.java
@@ -232,8 +232,38 @@ class KeywordRepositoryTest {
         });
     }
 
+    @Test
+    @DisplayName("커리큘럼 ID에 해당하는 모든 키워드들을 조회할 수 있다")
+    void findAllByCurriculumId() {
+        //given
+        final Long session1 = createSessionWithCurriculumId(1L);
+        final Long session2 = createSessionWithCurriculumId(1L);
+
+        final Keyword parent1 = createKeywordParent(
+            Keyword.createKeyword("자바", "자바에 대한 설명", 1, 1, session1, null));
+        createKeywordChildren(
+            Keyword.createKeyword("List", "List에 대한 설명", 1, 1, session1, parent1));
+        createKeywordChildren(
+            Keyword.createKeyword("List", "List에 대한 설명", 1, 1, session1, parent1));
+
+        createKeywordParent(
+            Keyword.createKeyword("자바", "자바에 대한 설명", 1, 1, session2, null));
+
+        //when
+        final List<Keyword> keywords = keywordRepository.findAllByCurriculumId(1L);
+
+        //then
+        assertThat(keywords).hasSize(4);
+    }
+
     private Long createSession() {
         Session session = new Session("테스트 세션");
+        sessionRepository.save(session);
+        return session.getId();
+    }
+
+    private Long createSessionWithCurriculumId(final Long curriculumId) {
+        Session session = new Session(curriculumId, "테스트 세션");
         sessionRepository.save(session);
         return session.getId();
     }

--- a/backend/src/test/java/wooteco/prolog/roadmap/repository/KeywordRepositoryTest.java
+++ b/backend/src/test/java/wooteco/prolog/roadmap/repository/KeywordRepositoryTest.java
@@ -1,12 +1,5 @@
 package wooteco.prolog.roadmap.repository;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertAll;
-
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
-import javax.persistence.EntityManager;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -17,6 +10,13 @@ import wooteco.prolog.roadmap.domain.repository.KeywordRepository;
 import wooteco.prolog.session.domain.Session;
 import wooteco.prolog.session.domain.repository.SessionRepository;
 import wooteco.support.utils.RepositoryTest;
+
+import javax.persistence.EntityManager;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 @RepositoryTest
 class KeywordRepositoryTest {
@@ -112,53 +112,6 @@ class KeywordRepositoryTest {
 
         // then
         assertThat(extractParentKeyword.size()).isEqualTo(1);
-    }
-
-    @Test
-    @DisplayName("세션 ID 리스트로 키워드 리스트를 조회한다")
-    void findBySessionIdIn() {
-        //given
-        final Curriculum curriculum = curriculumRepository.save(new Curriculum("커리큘럼1"));
-
-        final Session session1 = sessionRepository.save(new Session(curriculum.getId(), "세션1"));
-        final Session session2 = sessionRepository.save(new Session(curriculum.getId(), "세션2"));
-        final Session session3 = sessionRepository.save(new Session(curriculum.getId(), "세션3"));
-        final Session session4 = sessionRepository.save(new Session(curriculum.getId(), "세션4"));
-        final Session session5 = sessionRepository.save(new Session(curriculum.getId(), "세션5"));
-
-        final Keyword keyword1 = keywordRepository.save(
-            Keyword.createKeyword("자바1", "자바 설명1", 1, 5, session1.getId(), null));
-        final Keyword keyword2 = keywordRepository.save(
-            Keyword.createKeyword("자바2", "자바 설명2", 2, 5, session1.getId(), keyword1));
-        final Keyword keyword3 = keywordRepository.save(
-            Keyword.createKeyword("자바3", "자바 설명3", 3, 5, session1.getId(), null));
-        final Keyword keyword4 = keywordRepository.save(
-            Keyword.createKeyword("자바4", "자바 설명4", 4, 5, session1.getId(), keyword3));
-        keywordRepository.save(
-            Keyword.createKeyword("자바5", "자바 설명5", 5, 5, session2.getId(), null));
-        keywordRepository.save(
-            Keyword.createKeyword("자바6", "자바 설명6", 6, 5, session2.getId(), keyword1));
-        keywordRepository.save(
-            Keyword.createKeyword("자바7", "자바 설명7", 7, 5, session2.getId(), null));
-        keywordRepository.save(
-            Keyword.createKeyword("자바8", "자바 설명8", 8, 5, session3.getId(), keyword2));
-        final Keyword keyword9 = keywordRepository.save(
-            Keyword.createKeyword("자바9", "자바 설명9", 9, 5, session4.getId(), keyword2));
-        final Keyword keyword10 = keywordRepository.save(
-            Keyword.createKeyword("자바10", "자바 설명10", 10, 5, session5.getId(), null));
-
-        final HashSet<Long> sessionIds = new HashSet<>(
-            Arrays.asList(session1.getId(), session4.getId(), session5.getId())
-        );
-
-        //when
-        final List<Keyword> keywords = keywordRepository.findBySessionIdIn(sessionIds);
-
-        //then
-        assertThat(keywords)
-            .usingRecursiveComparison()
-            .ignoringFields("id", "parent.id")
-            .isEqualTo(Arrays.asList(keyword1, keyword2, keyword3, keyword4, keyword9, keyword10));
     }
 
     @Test


### PR DESCRIPTION
## #️⃣연관된 이슈

- #1609 

## 📝작업 내용
- `roadmap` 패키지의 모든 Repository를 사용해서 자바 API를 통해 조립하던 기존 로직을 JPQL을 통해 개선했습니다.
  - 커리큘럼 ID에 해당하는 모든 키워드를 조회하는 `findAllByCurriculumId()` 구현
  - 키워드 ID 별로 총 퀴즈 개수를 조회하는 `findTotalQuizCount()` 구현
  - 키워드 ID 별로 현재 멤버가 답변한 총 퀴즈 개수를 조회하는 `findDoneQuizCountByMemberId()` 구현

## 기존 요구 사항
- 세션 ID에 해당하는 키워드들을 한 번에 조회할 수 있다

## 바뀐 요구 사항
- 커리큘럼 ID에 해당하는 모든 세션의 모든 키워드들을 한 번에 조회할 수 있다
  - 각 키워드별 총 퀴즈 개수도 같이 반환한다
  - 로그인한 유저가 조회하면 각 키워드별 답변한 총 퀴즈 개수도 같이 반환한다
  - 비로그인한 유저가 조회하면 각 키워드별 답변한 총 퀴즈 개수는 0개이다
