### PR TITLE
Feature/integrate ai feedback qna

### DIFF
--- a/backend/src/main/java/wooteco/prolog/session/application/AnswerFeedbackService.java
+++ b/backend/src/main/java/wooteco/prolog/session/application/AnswerFeedbackService.java
@@ -14,6 +14,8 @@ import wooteco.prolog.session.domain.QnaFeedbackProvider;
 import wooteco.prolog.session.domain.QnaFeedbackRequest;
 import wooteco.prolog.session.domain.repository.AnswerFeedbackRepository;
 
+import java.util.List;
+
 @Service
 public class AnswerFeedbackService {
 
@@ -57,5 +59,10 @@ public class AnswerFeedbackService {
 
         answerFeedbackRepository.save(answerFeedback);
         log.debug("AnswerFeedback saved: {}", answerFeedback);
+    }
+
+    @Transactional(readOnly = true)
+    public List<AnswerFeedback> findRecentByMemberIdAndQuestionIds(final Long memberId, final List<Long> questionIds) {
+        return answerFeedbackRepository.findRecentByMemberIdAndQuestionIdsAndVisible(memberId, questionIds);
     }
 }

--- a/backend/src/main/java/wooteco/prolog/session/application/AnswerFeedbackService.java
+++ b/backend/src/main/java/wooteco/prolog/session/application/AnswerFeedbackService.java
@@ -2,7 +2,6 @@ package wooteco.prolog.session.application;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
@@ -38,6 +37,11 @@ public class AnswerFeedbackService {
         log.debug("AnswerUpdatedEvent: {}", event);
 
         final var answer = event.getAnswer();
+        if (answer.getContent().isEmpty() || answer.getQuestion().getMission().getGoal().isEmpty()) {
+            log.debug("Answer content or mission goal is empty: {}", answer);
+            return;
+        }
+
         final var feedbackRequest = new QnaFeedbackRequest(
             answer.getQuestion().getMission().getGoal(),
             answer.getQuestion().getContent(),
@@ -52,5 +56,6 @@ public class AnswerFeedbackService {
         );
 
         answerFeedbackRepository.save(answerFeedback);
+        log.debug("AnswerFeedback saved: {}", answerFeedback);
     }
 }

--- a/backend/src/main/java/wooteco/prolog/session/domain/AnswerFeedback.java
+++ b/backend/src/main/java/wooteco/prolog/session/domain/AnswerFeedback.java
@@ -57,4 +57,16 @@ public class AnswerFeedback {
         this.contents = contents;
         this.visible = visible;
     }
+
+    public String getStrengths() {
+        return contents.strengths();
+    }
+
+    public String getImprovementPoints() {
+        return contents.improvementPoints();
+    }
+
+    public String getAdditionalLearning() {
+        return contents.additionalLearning();
+    }
 }

--- a/backend/src/main/java/wooteco/prolog/session/domain/AnswerFeedback.java
+++ b/backend/src/main/java/wooteco/prolog/session/domain/AnswerFeedback.java
@@ -1,5 +1,6 @@
 package wooteco.prolog.session.domain;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -31,10 +32,29 @@ public class AnswerFeedback {
     @Embedded
     private QnaFeedbackContents contents;
 
-    public AnswerFeedback(Question question, Long memberId, QnaFeedbackRequest request, QnaFeedbackContents contents) {
+    @Column
+    private boolean visible;
+
+    public AnswerFeedback(
+        final Question question,
+        final Long memberId,
+        final QnaFeedbackRequest request,
+        final QnaFeedbackContents contents
+    ) {
+        this(question, memberId, request, contents, false);
+    }
+
+    public AnswerFeedback(
+        final Question question,
+        final Long memberId,
+        final QnaFeedbackRequest request,
+        final QnaFeedbackContents contents,
+        final boolean visible
+    ) {
         this.question = question;
         this.memberId = memberId;
         this.request = request;
         this.contents = contents;
+        this.visible = visible;
     }
 }

--- a/backend/src/main/java/wooteco/prolog/session/domain/Question.java
+++ b/backend/src/main/java/wooteco/prolog/session/domain/Question.java
@@ -21,4 +21,8 @@ public class Question {
     @ManyToOne
     private Mission mission;
 
+    public Question(final String content, final Mission mission) {
+        this.content = content;
+        this.mission = mission;
+    }
 }

--- a/backend/src/main/java/wooteco/prolog/session/domain/repository/AnswerFeedbackRepository.java
+++ b/backend/src/main/java/wooteco/prolog/session/domain/repository/AnswerFeedbackRepository.java
@@ -1,8 +1,23 @@
 package wooteco.prolog.session.domain.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import wooteco.prolog.session.domain.AnswerFeedback;
+
+import java.util.List;
 
 public interface AnswerFeedbackRepository extends JpaRepository<AnswerFeedback, Long> {
 
+    @Query("""
+            SELECT af
+            FROM AnswerFeedback af
+            JOIN (
+                SELECT MAX(id) AS id
+                FROM AnswerFeedback
+                WHERE memberId = :memberId AND question.id IN (:questionIds) AND visible = TRUE
+                GROUP BY question.id
+            ) sub
+            ON af.id = sub.id
+            """)
+    List<AnswerFeedback> findRecentByMemberIdAndQuestionIdsAndVisible(Long memberId, List<Long> questionIds);
 }

--- a/backend/src/main/java/wooteco/prolog/session/ui/TempFeedbackController.java
+++ b/backend/src/main/java/wooteco/prolog/session/ui/TempFeedbackController.java
@@ -1,0 +1,38 @@
+package wooteco.prolog.session.ui;
+
+import lombok.AllArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import wooteco.prolog.session.domain.AnswerUpdatedEvent;
+import wooteco.prolog.session.domain.repository.AnswerRepository;
+
+import java.util.stream.IntStream;
+
+@RestController
+@RequestMapping("/feedbacks/ASDLKJWOIDSADASDSFDSLKJ")
+@AllArgsConstructor
+public class TempFeedbackController {
+
+    private final AnswerRepository answerRepository;
+
+    private final ApplicationEventPublisher applicationEventPublisher;
+
+    @GetMapping
+    public void show(
+        @RequestParam("startId") Long startId,
+        @RequestParam("endId") Long endId
+    ) {
+        final var ids = IntStream.rangeClosed(startId.intValue(), endId.intValue())
+            .mapToLong(Long::valueOf)
+            .boxed()
+            .toList();
+        final var answers = answerRepository.findAllById(ids);
+
+        answers.forEach(answer -> {
+            applicationEventPublisher.publishEvent(new AnswerUpdatedEvent(answer));
+        });
+    }
+}

--- a/backend/src/main/java/wooteco/prolog/studylog/application/dto/AnswerResponse.java
+++ b/backend/src/main/java/wooteco/prolog/studylog/application/dto/AnswerResponse.java
@@ -1,13 +1,17 @@
 package wooteco.prolog.studylog.application.dto;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.lang.Nullable;
 import wooteco.prolog.session.domain.Answer;
+import wooteco.prolog.session.domain.AnswerFeedback;
 import wooteco.prolog.session.domain.AnswerTemp;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @AllArgsConstructor
 @NoArgsConstructor
@@ -18,24 +22,63 @@ public class AnswerResponse {
     private String answerContent;
     private Long questionId;
     private String questionContent;
+    @Nullable
+    private String strengths;
+    @Nullable
+    private String improvementPoints;
+    @Nullable
+    private String additionalLearning;
+
+    public AnswerResponse(
+        final Long id,
+        final String answerContent,
+        final Long questionId,
+        final String questionContent
+    ) {
+        this.id = id;
+        this.answerContent = answerContent;
+        this.questionId = questionId;
+        this.questionContent = questionContent;
+    }
 
     public static List<AnswerResponse> emptyListOf() {
         return new ArrayList<>();
     }
 
     public static List<AnswerResponse> listOf(List<Answer> answers) {
+        return listOf(answers, List.of());
+    }
+
+    public static List<AnswerResponse> listOf(List<Answer> answers, List<AnswerFeedback> answerFeedbacks) {
+        return listOf(answers, answerFeedbacks.stream()
+            .collect(Collectors.toMap(answerFeedback -> answerFeedback.getQuestion().getId(), answerFeedback -> answerFeedback)));
+    }
+
+    public static List<AnswerResponse> listOf(List<Answer> answers, Map<Long, AnswerFeedback> answerFeedbacks) {
         if (answers == null || answers.isEmpty()) {
             return emptyListOf();
         }
 
         return answers.stream()
-            .map(answer -> new AnswerResponse(answer.getId(), answer.getContent(), answer.getQuestion().getId(),
-                answer.getQuestion().getContent()))
+            .map(answer -> of(answer, answerFeedbacks.get(answer.getQuestion().getId())))
             .collect(Collectors.toList());
     }
 
     public static AnswerResponse of(AnswerTemp answerTemp) {
         return new AnswerResponse(answerTemp.getId(), answerTemp.getContent(), answerTemp.getQuestion().getId(),
             answerTemp.getQuestion().getContent());
+    }
+
+    public static AnswerResponse of(Answer answer) {
+        return new AnswerResponse(answer.getId(), answer.getContent(), answer.getQuestion().getId(),
+            answer.getQuestion().getContent());
+    }
+
+    public static AnswerResponse of(Answer answer, AnswerFeedback answerFeedback) {
+        if (answerFeedback == null) {
+            return of(answer);
+        }
+        return new AnswerResponse(answer.getId(), answer.getContent(), answer.getQuestion().getId(),
+            answer.getQuestion().getContent(), answerFeedback.getStrengths(), answerFeedback.getImprovementPoints(), answerFeedback.getAdditionalLearning());
     }
 }

--- a/backend/src/main/java/wooteco/prolog/studylog/application/dto/StudylogResponse.java
+++ b/backend/src/main/java/wooteco/prolog/studylog/application/dto/StudylogResponse.java
@@ -1,9 +1,5 @@
 package wooteco.prolog.studylog.application.dto;
 
-import static java.util.stream.Collectors.toList;
-
-import java.time.LocalDateTime;
-import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -11,10 +7,16 @@ import wooteco.prolog.member.application.dto.MemberResponse;
 import wooteco.prolog.session.application.dto.MissionResponse;
 import wooteco.prolog.session.application.dto.SessionResponse;
 import wooteco.prolog.session.domain.Answer;
+import wooteco.prolog.session.domain.AnswerFeedback;
 import wooteco.prolog.session.domain.Mission;
 import wooteco.prolog.session.domain.Session;
 import wooteco.prolog.studylog.domain.Studylog;
 import wooteco.prolog.studylog.domain.StudylogTag;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static java.util.stream.Collectors.toList;
 
 @NoArgsConstructor
 @AllArgsConstructor
@@ -172,7 +174,7 @@ public class StudylogResponse {
     }
 
     public static StudylogResponse of(Studylog studylog, List<Answer> answers) {
-        return of(studylog, answers, false, false, false);
+        return of(studylog, answers, List.of(), false, false, false);
     }
 
     public static StudylogResponse of(Studylog studylog, boolean scrap, boolean read, Long memberId) {
@@ -222,7 +224,7 @@ public class StudylogResponse {
         );
     }
 
-    public static StudylogResponse of(Studylog studylog, List<Answer> answers,
+    public static StudylogResponse of(Studylog studylog, List<Answer> answers, List<AnswerFeedback> answerFeedbacks,
                                       boolean scraped, boolean read, boolean liked) {
         List<StudylogTag> studylogTags = studylog.getStudylogTags();
         List<TagResponse> tagResponses = toTagResponses(studylogTags);
@@ -234,7 +236,7 @@ public class StudylogResponse {
             studylog.getUpdatedAt(),
             SessionResponse.of(studylog.getSession()),
             MissionResponse.of(studylog.getMission()),
-            AnswerResponse.listOf(answers),
+            AnswerResponse.listOf(answers, answerFeedbacks),
             studylog.getTitle(),
             studylog.getContent(),
             tagResponses,

--- a/backend/src/main/resources/db/migration/prod/V14__alter_table_answer_feedback.sql
+++ b/backend/src/main/resources/db/migration/prod/V14__alter_table_answer_feedback.sql
@@ -1,0 +1,2 @@
+ALTER TABLE prolog.answer_feedback
+    ADD COLUMN visible BOOLEAN NOT NULL DEFAULT FALSE;

--- a/backend/src/test/java/wooteco/prolog/session/domain/repository/AnswerFeedbackRepositoryTest.java
+++ b/backend/src/test/java/wooteco/prolog/session/domain/repository/AnswerFeedbackRepositoryTest.java
@@ -1,0 +1,75 @@
+package wooteco.prolog.session.domain.repository;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import wooteco.prolog.member.domain.Member;
+import wooteco.prolog.member.domain.Role;
+import wooteco.prolog.member.domain.repository.MemberRepository;
+import wooteco.prolog.session.domain.AnswerFeedback;
+import wooteco.prolog.session.domain.Mission;
+import wooteco.prolog.session.domain.QnaFeedbackContents;
+import wooteco.prolog.session.domain.QnaFeedbackRequest;
+import wooteco.prolog.session.domain.Question;
+import wooteco.prolog.session.domain.Session;
+import wooteco.support.utils.RepositoryTest;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@RepositoryTest
+class AnswerFeedbackRepositoryTest {
+
+    private static final QnaFeedbackRequest QNA_FEEDBACK_REQUEST = new QnaFeedbackRequest("", "", "");
+    private static final QnaFeedbackContents QNA_FEEDBACK_CONTENTS = new QnaFeedbackContents("", "", "", 1);
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private SessionRepository sessionRepository;
+
+    @Autowired
+    private MissionRepository missionRepository;
+
+    @Autowired
+    private QuestionRepository questionRepository;
+
+    @Autowired
+    private AnswerFeedbackRepository answerFeedbackRepository;
+
+
+    @DisplayName("가장 마지막에 추가된 피드백을 반환한다.")
+    @Test
+    void findRecentByMemberIdAndQuestionIds() {
+        //given
+        final var member = memberRepository.save(new Member("jaeyeonling", "jaeyeonling", Role.CREW, 1L, "imageUrl"));
+        final var session = sessionRepository.save(new Session("테스트용 세션"));
+        final var mission = missionRepository.save(new Mission("테스트용 미션", session));
+
+        final var question = questionRepository.save(new Question("1번 질문입니다.", mission));
+        final var question2 = questionRepository.save(new Question("2번 질문입니다.", mission));
+        final var question3 = questionRepository.save(new Question("3번 질문입니다.", mission));
+
+        final var answerFeedback_1_1 = answerFeedbackRepository.save(new AnswerFeedback(question, member.getId(), QNA_FEEDBACK_REQUEST, QNA_FEEDBACK_CONTENTS, true));
+        final var answerFeedback_1_2 = answerFeedbackRepository.save(new AnswerFeedback(question, member.getId(), QNA_FEEDBACK_REQUEST, QNA_FEEDBACK_CONTENTS, true));
+        final var answerFeedback_1_3 = answerFeedbackRepository.save(new AnswerFeedback(question, member.getId(), QNA_FEEDBACK_REQUEST, QNA_FEEDBACK_CONTENTS, false));
+        final var answerFeedback_2_1 = answerFeedbackRepository.save(new AnswerFeedback(question2, member.getId(), QNA_FEEDBACK_REQUEST, QNA_FEEDBACK_CONTENTS, true));
+        final var answerFeedback_3_1 = answerFeedbackRepository.save(new AnswerFeedback(question3, member.getId(), QNA_FEEDBACK_REQUEST, QNA_FEEDBACK_CONTENTS, true));
+
+        final var expected = List.of(answerFeedback_1_2, answerFeedback_2_1, answerFeedback_3_1);
+
+        // when
+        final var answerFeedbacks = answerFeedbackRepository.findRecentByMemberIdAndQuestionIdsAndVisible(
+            member.getId(),
+            List.of(question.getId(), question2.getId(), question3.getId())
+        );
+
+        assertAll(
+            () -> assertThat(answerFeedbacks).hasSize(3),
+            () -> assertThat(answerFeedbacks).containsExactlyElementsOf(expected)
+        );
+    }
+}

--- a/backend/src/test/java/wooteco/prolog/studylog/application/StudylogServiceTest.java
+++ b/backend/src/test/java/wooteco/prolog/studylog/application/StudylogServiceTest.java
@@ -22,6 +22,7 @@ import wooteco.prolog.member.application.dto.MemberResponse;
 import wooteco.prolog.member.domain.Member;
 import wooteco.prolog.member.domain.Role;
 import wooteco.prolog.organization.application.OrganizationService;
+import wooteco.prolog.session.application.AnswerFeedbackService;
 import wooteco.prolog.session.application.AnswerService;
 import wooteco.prolog.session.application.MissionService;
 import wooteco.prolog.session.application.SessionService;
@@ -104,6 +105,8 @@ class StudylogServiceTest {
     private MissionService missionService;
     @Mock
     private AnswerService answerService;
+    @Mock
+    private AnswerFeedbackService answerFeedbackService;
     @Mock
     private OrganizationService organizationService;
     @Mock


### PR DESCRIPTION
이 풀 리퀘스트에는 피드백 기능을 개선하고 스터디 로그 시스템과 통합하는 다양한 변경 사항이 포함되어 있습니다. 주요 변경 사항으로는 피드백 가시성(visible) 추가, 임시 피드백 컨트롤러 생성, 스터디 로그 서비스 업데이트 등이 있습니다.

✅ 피드백 기능 개선
AnswerFeedbackService.java

답변 내용이 비어있거나 미션 목표가 없는 경우를 처리하는 검사를 추가
멤버 ID와 질문 ID를 기준으로 최근 피드백을 조회하는 메서드 추가
AnswerFeedback.java

visible(가시성) 컬럼 추가
피드백 정보를 조회하는 메서드 추가
AnswerFeedbackRepository.java

멤버 ID 및 질문 ID를 기준으로 최근 가시성 있는(visible) 피드백을 찾는 쿼리 추가
✅ 스터디 로그 시스템과의 통합
StudylogService.java

AnswerFeedbackService를 활용하여 피드백 데이터를 조회하도록 통합
스터디 로그 응답에 피드백 정보를 포함하도록 메서드 수정
AnswerResponse.java

피드백 정보를 응답 데이터에 포함
StudylogResponse.java

스터디 로그 응답에 피드백 정보를 포함하도록 변경
✅ 추가 변경 사항
TempFeedbackController.java

피드백 이벤트를 시뮬레이션하기 위한 임시 피드백 컨트롤러 생성
V14__alter_table_answer_feedback.sql

answer_feedback 테이블에 visible 컬럼을 추가하는 데이터베이스 마이그레이션 스크립트 작성

🚀 이번 변경 사항을 통해 피드백 시스템이 보다 체계적으로 동작하며, 스터디 로그와의 연계성이 강화되었습니다.