### PR TITLE
fix: 인터뷰 페이지에서 공통된 API 콜 하도록 수정

### DIFF
--- a/.github/workflows/sonar-build.yml
+++ b/.github/workflows/sonar-build.yml
@@ -31,17 +31,20 @@ jobs:
           distribution: 'corretto'
           java-version: 21
       - name: Cache SonarCloud packages
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar
-          restore-keys: ${{ runner.os }}-sonar
+          restore-keys: |
+            ${{ runner.os }}-sonar
+
       - name: Cache Gradle packages
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
-          restore-keys: ${{ runner.os }}-gradle
+          restore-keys: |
+            ${{ runner.os }}-gradle-
       - name: Build
         run: ./backend/gradlew flywayClean flywayBaseline flywayMigrate build -Dflyway.baselineVersion=0
       - name: Analyze

--- a/frontend/src/pages/InterviewPage/InterviewSession.tsx
+++ b/frontend/src/pages/InterviewPage/InterviewSession.tsx
@@ -1,10 +1,6 @@
 import React, { useState, useRef, useEffect } from 'react';
 import styled from '@emotion/styled';
-import axios from 'axios';
-
-const api = axios.create({
-  baseURL: 'http://localhost:8080',
-});
+import { client } from '../../apis';
 
 const Container = styled.div`
   display: flex;
@@ -200,7 +196,7 @@ const InterviewSession = ({
 
     try {
       const accessToken = localStorage.getItem('accessToken');
-      const response = await api.post(
+      const response = await client.post(
         `/interviews/${session.id}/answers`,
         { answer: newMessage.content },
         {
@@ -224,7 +220,7 @@ const InterviewSession = ({
 
     try {
       const accessToken = localStorage.getItem('accessToken');
-      const response = await api.post(
+      const response = await client.post(
         `/interviews/${session.id}/restart`,
         {},
         {
@@ -244,7 +240,7 @@ const InterviewSession = ({
 
     try {
       const accessToken = localStorage.getItem('accessToken');
-      await api.post(
+      await client.post(
         `/interviews/${session.id}/quit`,
         {},
         {


### PR DESCRIPTION
이 풀 리퀘스트는 `InterviewPage` 컴포넌트에서 API 호출 방식을 리팩터링하여 각 파일마다 새로운 Axios 인스턴스를 생성하는 대신 중앙 집중화된 `client` 모듈을 사용하도록 변경했습니다. 또한, `InterviewSetup`에서 조건문 로직과 에러 처리에 대한 소폭 개선도 포함되어 있습니다.

### API 리팩터링:
* `InterviewSession` 및 `InterviewSetup` 컴포넌트(`frontend/src/pages/InterviewPage/InterviewSession.tsx`, `frontend/src/pages/InterviewPage/InterviewSetup.tsx`)에서 로컬로 정의된 Axios 인스턴스(`api`)를 공유 `client` 모듈로 교체했습니다. [[1]] [[2]]
* `InterviewSession`에서 `/answers`, `/restart`, `/quit` 등의 엔드포인트에 대한 모든 API 호출을 `client.post`로 변경했습니다. [[1]] [[2]] [[3]]
* `InterviewSetup`에서 `/sessions/mine`, `/missions`, `/questions`, `/interviews` 등의 엔드포인트에 대해 `client.get` 및 `client.post`를 사용하도록 API 호출을 업데이트했습니다. [[1]] [[2]] [[3]] [[4]]

### 로직 및 에러 처리 개선:
* `InterviewSetup` 내 `selectedSession` 및 `selectedMission`에 대한 조건문을 단순화하여 중복 코드를 줄였습니다. [[1]] [[2]]
* `InterviewSetup`의 `handleStartInterview` 함수에서 `selectedSession` 및 `selectedMission`에 대한 추가 유효성 검사를 포함시키고, 인터뷰 시작 실패 시 알림 메시지를 추가했습니다.

- InterviewSetup 및 InterviewSession에서 로컬 Axios 인스턴스를 `src/apis`의 공유 'client'로 교체했습니다.
- 이 변경은 API 요청의 유지보수성과 일관성을 향상시킵니다.
