### PR TITLE
feat(interview): 세션을 기준으로 미션을 필터링

### DIFF
--- a/backend/src/main/java/wooteco/prolog/session/application/MissionService.java
+++ b/backend/src/main/java/wooteco/prolog/session/application/MissionService.java
@@ -46,6 +46,10 @@ public class MissionService {
         return MissionResponse.listOf(missionRepository.findAll());
     }
 
+    public List<MissionResponse> findAllBySessionId(final long sessionId) {
+        return MissionResponse.listOf(missionRepository.findBySessionId(sessionId));
+    }
+
     public Mission findById(Long id) {
         return missionRepository.findById(id)
             .orElseThrow(() -> new BadRequestException(MISSION_NOT_FOUND));

--- a/backend/src/main/java/wooteco/prolog/session/domain/repository/MissionRepository.java
+++ b/backend/src/main/java/wooteco/prolog/session/domain/repository/MissionRepository.java
@@ -10,4 +10,6 @@ public interface MissionRepository extends JpaRepository<Mission, Long> {
     Optional<Mission> findByName(String name);
 
     List<Mission> findBySessionIdIn(List<Long> sessionIds);
+
+    List<Mission> findBySessionId(long sessionId);
 }

--- a/backend/src/main/java/wooteco/prolog/session/ui/MissionController.java
+++ b/backend/src/main/java/wooteco/prolog/session/ui/MissionController.java
@@ -1,11 +1,11 @@
 package wooteco.prolog.session.ui;
 
-import java.util.List;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import wooteco.prolog.login.aop.MemberOnly;
 import wooteco.prolog.login.domain.AuthMemberPrincipal;
@@ -13,6 +13,8 @@ import wooteco.prolog.login.ui.LoginMember;
 import wooteco.prolog.session.application.MissionService;
 import wooteco.prolog.session.application.dto.MissionRequest;
 import wooteco.prolog.session.application.dto.MissionResponse;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/missions")
@@ -25,9 +27,14 @@ public class MissionController {
     }
 
     @GetMapping
-    public ResponseEntity<List<MissionResponse>> showMissions() {
-        List<MissionResponse> responses = missionService.findAll();
-        return ResponseEntity.ok(responses);
+    public ResponseEntity<List<MissionResponse>> showMissions(
+        @RequestParam(required = false) final Long sessionId
+    ) {
+        if (sessionId == null) {
+            return ResponseEntity.ok(missionService.findAll());
+        } else {
+            return ResponseEntity.ok(missionService.findAllBySessionId(sessionId));
+        }
     }
 
     @MemberOnly


### PR DESCRIPTION
다음은 `sessionId`를 기준으로 미션을 필터링하는 기능을 백엔드에 추가한 풀 리퀘스트입니다. 이 변경은 `MissionController`, `MissionService`, `MissionRepository`에 반영되었습니다. 주요 변경 사항은 다음과 같습니다:

### 백엔드 API 개선

* **MissionController**: `showMissions` 엔드포인트에 선택적 `sessionId` 쿼리 파라미터를 추가했습니다. `sessionId`가 제공되면 해당 세션 ID에 해당하는 미션들만 반환하고, 없으면 전체 미션을 반환합니다.  
  (`backend/src/main/java/wooteco/prolog/session/ui/MissionController.java`)

### 서비스 레이어 업데이트

* **MissionService**: 특정 세션 ID에 해당하는 미션 목록을 조회하는 `findAllBySessionId` 메서드를 추가했습니다.  
  (`backend/src/main/java/wooteco/prolog/session/application/MissionService.java`)

### 리포지토리 레이어 업데이트

* **MissionRepository**: 세션 ID로 미션을 조회하는 `findBySessionId` 메서드를 추가했습니다.  
  (`backend/src/main/java/wooteco/prolog/session/domain/repository/MissionRepository.java`)

### 사소한 코드 정리

* `MissionController`에서 `@RequestParam`을 포함한 import 구문을 정리하고, 전체 import 구조를 개선했습니다.  
  (`backend/src/main/java/wooteco/prolog/session/ui/MissionController.java`) [[1]](diffhunk://#diff-800cebdf61d9ce4298409deea37c9ae426fc00b45f912ef670cae7692e49c3a8L3-R8) [[2]](diffhunk://#diff-800cebdf61d9ce4298409deea37c9ae426fc00b45f912ef670cae7692e49c3a8R17-R18)
